### PR TITLE
Remove node "Europe" from text of example 3.1

### DIFF
--- a/doc/specs.tex
+++ b/doc/specs.tex
@@ -99,7 +99,6 @@ Otherwise it will terminate with an error message.
 The parity game depicted in Fig.~\ref{fig:examplegame} can, for example, be specified as follows.
 \begin{verbatim}
      parity 4;
-     1 3 0 1,3,4 "Europe";
      0 6 1 4,2 "Africa";
      4 5 1 0 "Antarctica";
      1 8 1 2,4,3 "America";


### PR DESCRIPTION
This node does not appear in Figure 3.1 and causes this example to fail as node '1' is defined twice.
