### PR TITLE
Update old font commands

### DIFF
--- a/doc/develop.tex
+++ b/doc/develop.tex
@@ -278,7 +278,7 @@ the subdirectory \texttt{src}, i.e.\ when we speak about module \texttt{Basics} 
 directory for example then this can be found in the file \texttt{src/paritygame/basics.ml}.
 
 %\paragraph{Basics Module}
-\subsection{The {\tt Basics} Module}
+\subsection{The {\ttfamily Basics} Module}
 
 This module in the subdirectory \texttt{utils} contains only one function at the moment which is used to
 output string messages to \texttt{STDOUT} depending on the configured verbosity level.
@@ -297,7 +297,7 @@ Predefined verbosity level constant for debug output (3).
 \end{description}
 
 
-\subsection{The {\tt Paritygame} Module}
+\subsection{The {\ttfamily Paritygame} Module}
 
 This module in the \texttt{paritygame} subdirectory contains many useful routines for creating, accessing,
 manipulating, printing, decomposing and generally handling parity games. Some of the most useful functions
@@ -377,7 +377,7 @@ are added to \verb+strategy+.
 \end{description}
 
 
-\subsection{The {\tt Univsolve} Module}
+\subsection{The {\ttfamily Univsolve} Module}
 
 This module in the \texttt{paritygame} subdirectory contains the universal solver and some possibly helpful functions
 for the universal solving process:

--- a/doc/implalg.tex
+++ b/doc/implalg.tex
@@ -28,14 +28,14 @@ reaching the set of nodes with maximal priority in the game.
 \begin{center}
   \begin{tabular}{|l|p{8cm}|}
     \hline
-    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Algorithm \nextalg\ (Recursive Algorithm)} \\ \hline\hline
-    \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & W.~Zielonka\\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{TCS::Zielonka1998} \\ \hline
-    \rule[-8mm]{0mm}{13mm}{\bf Short description} & Decomposition into subgames with recursion on number
+    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Algorithm \nextalg\ (Recursive Algorithm)} \\ \hline\hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & W.~Zielonka\\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{TCS::Zielonka1998} \\ \hline
+    \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Decomposition into subgames with recursion on number
                               of nodes and priorities \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & $\mathcal{O}(e \cdot n^d)$ \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(e \cdot n)$ \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & none \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & $\mathcal{O}(e \cdot n^d)$ \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(e \cdot n)$ \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & none \\ \hline
   \end{tabular}
 \end{center}
 
@@ -49,14 +49,14 @@ reaching the set of nodes with maximal priority in the game.
 % \begin{center}
   % \begin{tabular}{|l|p{8cm}|}
     % \hline
-    % \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Algorithm \nextalg\ (Recursive Preservation Algorithm)} \\ \hline\hline
-    % \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & O.~Friedmann\\ \hline
-% %    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{TCS::Zielonka1998} \\ \hline
-    % \rule[-8mm]{0mm}{13mm}{\bf Short description} & Decomposition into subgames with recursion on number
+    % \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Algorithm \nextalg\ (Recursive Preservation Algorithm)} \\ \hline\hline
+    % \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & O.~Friedmann\\ \hline
+% %    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{TCS::Zielonka1998} \\ \hline
+    % \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Decomposition into subgames with recursion on number
                               % of nodes and priorities by trying to keep as much computed information as possible\\ \hline
-    % \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & $\mathcal{O}(e \cdot n^d)$ \\ \hline
-    % \rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(e \cdot n)$ \\ \hline
-% %    \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & none \\ \hline
+    % \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & $\mathcal{O}(e \cdot n^d)$ \\ \hline
+    % \rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(e \cdot n)$ \\ \hline
+% %    \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & none \\ \hline
   % \end{tabular}
 % \end{center}
 
@@ -78,13 +78,13 @@ invalidated.
 \begin{center}
   \begin{tabular}{|l|p{8cm}|}
     \hline
-    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Algorithm \nextalg\ (Model Checking Algorithm)} \\ \hline\hline
-    \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & P.~Stevens and C.~Stirling\\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{StevensStirling98} \\ \hline
-    \rule[-8mm]{0mm}{13mm}{\bf Short description} & Exploring the game depth-first, detecting cycles and backtracking subsequently for other possible moves \\ \hline
-%     \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & not given in the literature  \\ \hline
-%     \rule[-3mm]{0mm}{8mm}{\bf Space complexity} & not given in the literature  \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & none \\ \hline
+    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Algorithm \nextalg\ (Model Checking Algorithm)} \\ \hline\hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & P.~Stevens and C.~Stirling\\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{StevensStirling98} \\ \hline
+    \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Exploring the game depth-first, detecting cycles and backtracking subsequently for other possible moves \\ \hline
+%     \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & not given in the literature  \\ \hline
+%     \rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & not given in the literature  \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & none \\ \hline
   \end{tabular}
 \end{center}
 There are no sensible estimations on the worst-case time and space complexities of this algorithm in the
@@ -99,13 +99,13 @@ The process of valuating the current strategy and subsequently picking a new one
 \begin{center}
   \begin{tabular}{|l|p{8cm}|}
     \hline
-    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Algorithm \nextalg\ (Strategy Improvement Algorithm)} \\ \hline\hline
-    \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & M.~Jurdzi{\'n}ski and J.~V\"oge\\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{conf/cav/VogeJ00,SchVog00} \\ \hline
-    \rule[-8mm]{0mm}{13mm}{\bf Short description} & Iteratively improves an initialization strategy until it satisfies a winning-strategy-predicate \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & $\mathcal{O}(2^e \cdot n \cdot e)$ \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(n^2 + n \cdot \log d + e)$  \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & none \\ \hline
+    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Algorithm \nextalg\ (Strategy Improvement Algorithm)} \\ \hline\hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & M.~Jurdzi{\'n}ski and J.~V\"oge\\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{conf/cav/VogeJ00,SchVog00} \\ \hline
+    \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Iteratively improves an initialization strategy until it satisfies a winning-strategy-predicate \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & $\mathcal{O}(2^e \cdot n \cdot e)$ \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(n^2 + n \cdot \log d + e)$  \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & none \\ \hline
   \end{tabular}
 \end{center}
 
@@ -116,13 +116,13 @@ This strategy improvement algorithm due to Schewe guarantees to select, in each 
 \begin{center}
   \begin{tabular}{|l|p{8cm}|}
     \hline
-    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Algorithm \nextalg\ (Optimal Strategy Improvement Method)} \\ \hline\hline
-    \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & S. Schewe\\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{conf/csl/Schewe08} \\ \hline
-    \rule[-8mm]{0mm}{13mm}{\bf Short description} & Iteratively improves an estimation until a fixed point is reached \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & $\mathcal{O}(e \cdot (\frac{n+d}{d})^d \cdot \log(\frac{n+d}{d}))$ \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(n^2)$  \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & none \\ \hline
+    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Algorithm \nextalg\ (Optimal Strategy Improvement Method)} \\ \hline\hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & S. Schewe\\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{conf/csl/Schewe08} \\ \hline
+    \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Iteratively improves an estimation until a fixed point is reached \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & $\mathcal{O}(e \cdot (\frac{n+d}{d})^d \cdot \log(\frac{n+d}{d}))$ \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(n^2)$  \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & none \\ \hline
   \end{tabular}
 \end{center}
 
@@ -135,13 +135,13 @@ correspond to those of the original parity game.
 \begin{center}
   \begin{tabular}{|l|p{8cm}|}
     \hline
-    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Algorithm \nextalg\ (Strategy Improvement for DPGs)} \\ \hline\hline
-    \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & A.~Puri\\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{purithesis} \\ \hline
-    \rule[-8mm]{0mm}{13mm}{\bf Short description} & Iteratively improves an estimation until a fixed point is reached \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & $\mathcal{O}(e \cdot (\frac{n+d}{d})^d \cdot \log(\frac{n+d}{d}))$ \\ \hline
-    %\rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(n^2)$  \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & none \\ \hline
+    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Algorithm \nextalg\ (Strategy Improvement for DPGs)} \\ \hline\hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & A.~Puri\\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{purithesis} \\ \hline
+    \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Iteratively improves an estimation until a fixed point is reached \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & $\mathcal{O}(e \cdot (\frac{n+d}{d})^d \cdot \log(\frac{n+d}{d}))$ \\ \hline
+    %\rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(n^2)$  \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & none \\ \hline
   \end{tabular}
 \end{center}
 
@@ -152,13 +152,13 @@ that are required to solve the game.
 \begin{center}
   \begin{tabular}{|l|p{8cm}|}
     \hline
-    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Algorithm \nextalg\ (Probabilistic Strategy Improvement)} \\ \hline\hline
-    \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & H.~Bj{\"o}rklund and S.~Vorobyov \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{BjoerklundVorobyov/2007} \\ \hline
-    \rule[-8mm]{0mm}{13mm}{\bf Short description} & Iteratively improves an estimation until a fixed point is reached \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & $\mathcal{O}(e \cdot (\frac{n+d}{d})^d \cdot \log(\frac{n+d}{d}))$ \\ \hline
-    %\rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(n^2)$  \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & none \\ \hline
+    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Algorithm \nextalg\ (Probabilistic Strategy Improvement)} \\ \hline\hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & H.~Bj{\"o}rklund and S.~Vorobyov \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{BjoerklundVorobyov/2007} \\ \hline
+    \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Iteratively improves an estimation until a fixed point is reached \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & $\mathcal{O}(e \cdot (\frac{n+d}{d})^d \cdot \log(\frac{n+d}{d}))$ \\ \hline
+    %\rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(n^2)$  \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & none \\ \hline
   \end{tabular}
 \end{center}
 
@@ -169,13 +169,13 @@ that are required to solve the game.
 \begin{center}
   \begin{tabular}{|l|p{8cm}|}
     \hline
-    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Algorithm \nextalg\ (Probabilistic Strategy Improvement 2)} \\ \hline\hline
-    \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & H.~Bj{\"o}rklund, S.~Sandberg and S.~Vorobyov \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{DBLP:conf/stacs/BjorklundSV03} \\ \hline
-    \rule[-8mm]{0mm}{13mm}{\bf Short description} & Iteratively improves an estimation until a fixed point is reached \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & $\mathcal{O}(e \cdot (\frac{n+d}{d})^d \cdot \log(\frac{n+d}{d}))$ \\ \hline
-    %\rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(n^2)$  \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & none \\ \hline
+    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Algorithm \nextalg\ (Probabilistic Strategy Improvement 2)} \\ \hline\hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & H.~Bj{\"o}rklund, S.~Sandberg and S.~Vorobyov \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{DBLP:conf/stacs/BjorklundSV03} \\ \hline
+    \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Iteratively improves an estimation until a fixed point is reached \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & $\mathcal{O}(e \cdot (\frac{n+d}{d})^d \cdot \log(\frac{n+d}{d}))$ \\ \hline
+    %\rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(n^2)$  \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & none \\ \hline
   \end{tabular}
 \end{center}
 
@@ -185,13 +185,13 @@ A local version of the strategy iteration paradigm.
 \begin{center}
   \begin{tabular}{|l|p{8cm}|}
     \hline
-    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Algorithm \nextalg\ (Local Strategy Improvement)} \\ \hline\hline
-    \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & O.~Friedmann and M.~Lange \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{fl-gandalf10,FriedmannL:JFCS:2011} \\ \hline
-    \rule[-8mm]{0mm}{13mm}{\bf Short description} & Iteratively improves an estimation until a fixed point is reached \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & $\mathcal{O}(e \cdot (\frac{n+d}{d})^d \cdot \log(\frac{n+d}{d}))$ \\ \hline
-    %\rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(n^2)$  \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & none \\ \hline
+    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Algorithm \nextalg\ (Local Strategy Improvement)} \\ \hline\hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & O.~Friedmann and M.~Lange \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{fl-gandalf10,FriedmannL:JFCS:2011} \\ \hline
+    \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Iteratively improves an estimation until a fixed point is reached \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & $\mathcal{O}(e \cdot (\frac{n+d}{d})^d \cdot \log(\frac{n+d}{d}))$ \\ \hline
+    %\rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(n^2)$  \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & none \\ \hline
   \end{tabular}
 \end{center}
 
@@ -209,15 +209,15 @@ of the game is found when the iteration tries to increase values beyond their pr
 \begin{center}
   \begin{tabular}{|l|p{8cm}|}
     \hline
-    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Algorithm \nextalg\ (Small Progress Measures Algorithm)}
+    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Algorithm \nextalg\ (Small Progress Measures Algorithm)}
                     \\ \hline\hline
-    \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & M.~Jurdzi{\'n}ski \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{Jurdzinski/00} \\ \hline
-    \rule[-8mm]{0mm}{13mm}{\bf Short description} & Iteratively increase lexicographically ordered tuples
+    \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & M.~Jurdzi{\'n}ski \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{Jurdzinski/00} \\ \hline
+    \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Iteratively increase lexicographically ordered tuples
                               \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & $\mathcal{O}(d\cdot e \cdot (\frac{n}{d})^{d/2})$ \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(d\cdot n \cdot \log n)$ \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & tight computation of maximal values \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & $\mathcal{O}(d\cdot e \cdot (\frac{n}{d})^{d/2})$ \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(d\cdot n \cdot \log n)$ \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & tight computation of maximal values \\ \hline
   \end{tabular}
 \end{center}
 The performance of the algorithm depends very much on a good approximation of the maximal values in
@@ -258,13 +258,13 @@ positional strategies.
 \begin{center}
   \begin{tabular}{|l|p{8cm}|}
     \hline
-    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Algorithm \nextalg\ (Small Progress Measures Reduction to SAT)} \\ \hline\hline
-    \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & M.~Lange \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{lange-gdv05} \\ \hline
-    \rule[-8mm]{0mm}{13mm}{\bf Short description} & Symbolic encoding in propositional logic of the
+    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Algorithm \nextalg\ (Small Progress Measures Reduction to SAT)} \\ \hline\hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & M.~Lange \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{lange-gdv05} \\ \hline
+    \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Symbolic encoding in propositional logic of the
                                small progress measure algorithm \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & $\mathcal{O}(e\cdot d)$ + running time of the SAT solver \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(e\cdot d)$ + space needed by the SAT solver  \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & $\mathcal{O}(e\cdot d)$ + running time of the SAT solver \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(e\cdot d)$ + space needed by the SAT solver  \\ \hline
   \end{tabular}
 \end{center}
 % The SAT solver that is currently used is the library version of \textsc{zChaff} \cite{Moskewicz2001a},
@@ -282,13 +282,13 @@ formula is always satisfiable.
 \begin{center}
   \begin{tabular}{|l|p{8cm}|}
     \hline
-    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Algorithm \nextalg\ (Direct Reduction to SAT)} \\ \hline\hline
-    \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & O.~Friedmann \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{lange-gdv05} \\ \hline
-    \rule[-8mm]{0mm}{13mm}{\bf Short description} & Symbolic encoding in propositional logic of the
+    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Algorithm \nextalg\ (Direct Reduction to SAT)} \\ \hline\hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & O.~Friedmann \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{lange-gdv05} \\ \hline
+    \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Symbolic encoding in propositional logic of the
                                a direct predicate \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & $\mathcal{O}(n^3)$ + running time of the SAT solver \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(n^3)$ + space needed by the SAT solver  \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & $\mathcal{O}(n^3)$ + running time of the SAT solver \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(n^3)$ + space needed by the SAT solver  \\ \hline
   \end{tabular}
 \end{center}
 
@@ -306,13 +306,13 @@ dominions in subsequent recursive calls).
 \begin{center}
   \begin{tabular}{|l|p{8cm}|}
     \hline
-    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Algorithm \nextalg\ (Dominion Decomposition Algorithm)} \\ \hline\hline
-    \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & M.~Jurdzi{\'n}ski, M. Paterson, and U. Zwick\\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{JPZ06} \\ \hline
-    \rule[-8mm]{0mm}{13mm}{\bf Short description} & Brute-force search for small dominions with subsequent decomposition into subgames with recursion on number of nodes and priorities \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & $n^{O(\sqrt{n})}$ \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(e \cdot n)$  \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & none \\ \hline
+    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Algorithm \nextalg\ (Dominion Decomposition Algorithm)} \\ \hline\hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & M.~Jurdzi{\'n}ski, M. Paterson, and U. Zwick\\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{JPZ06} \\ \hline
+    \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Brute-force search for small dominions with subsequent decomposition into subgames with recursion on number of nodes and priorities \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & $n^{O(\sqrt{n})}$ \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(e \cdot n)$  \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & none \\ \hline
   \end{tabular}
 \end{center}
 
@@ -331,13 +331,13 @@ equal to that limit. If there is no small dominion the algorithm switches to the
 \begin{center}
   \begin{tabular}{|l|p{8cm}|}
     \hline
-    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Algorithm \nextalg\ (Big-Step Algorithm)} \\ \hline\hline
-    \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & S. Schewe\\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{Schewe/07/Parity} \\ \hline
-    \rule[-8mm]{0mm}{13mm}{\bf Short description} & Small progress measures-based search for small dominions with subsequent decomposition into subgames with recursion on number of nodes and priorities \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & $O(e \cdot n^{\frac{1}{3}d})$ \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}((e + d \cdot \log n) \cdot n)$  \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & none \\ \hline
+    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Algorithm \nextalg\ (Big-Step Algorithm)} \\ \hline\hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & S. Schewe\\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{Schewe/07/Parity} \\ \hline
+    \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Small progress measures-based search for small dominions with subsequent decomposition into subgames with recursion on number of nodes and priorities \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & $O(e \cdot n^{\frac{1}{3}d})$ \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}((e + d \cdot \log n) \cdot n)$  \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & none \\ \hline
   \end{tabular}
 \end{center}
 

--- a/doc/implheur.tex
+++ b/doc/implheur.tex
@@ -31,17 +31,17 @@ a \emph{don't know} answer and practically one of the algorithms above is used t
 % \begin{center}
 %   \begin{tabular}{|l|p{8cm}|}
 %     \hline
-%     \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Heuristic \nextheur\ (Duelling Strategies)} \\ \hline\hline
-%     \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & M.~Lange \\ \hline
-% %    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{lange-gdv05} \\ \hline
-%     \rule[-8mm]{0mm}{13mm}{\bf Short description} & select candidates for winning strategies by duelling two
+%     \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Heuristic \nextheur\ (Duelling Strategies)} \\ \hline\hline
+%     \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & M.~Lange \\ \hline
+% %    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{lange-gdv05} \\ \hline
+%     \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & select candidates for winning strategies by duelling two
 %                                strategies \\ \hline
-% %    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & --- \\ \hline
-%     \rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(n)$ \\ \hline
-%     \rule[-3mm]{0mm}{8mm}{\bf Soundness} & yes \\ \hline
-%     \rule[-3mm]{0mm}{8mm}{\bf Completeness} & no \\ \hline
-%     \rule[-3mm]{0mm}{8mm}{\bf Termination} & no \\ \hline
-%     \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & biased selection of strategies with preference to those that
+% %    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & --- \\ \hline
+%     \rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(n)$ \\ \hline
+%     \rule[-3mm]{0mm}{8mm}{\bfseries Soundness} & yes \\ \hline
+%     \rule[-3mm]{0mm}{8mm}{\bfseries Completeness} & no \\ \hline
+%     \rule[-3mm]{0mm}{8mm}{\bfseries Termination} & no \\ \hline
+%     \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & biased selection of strategies with preference to those that
 %                               have won duels before \\ \hline
 %   \end{tabular}
 % \end{center}
@@ -63,16 +63,16 @@ a \emph{don't know} answer and practically one of the algorithms above is used t
 % \begin{center}
 %   \begin{tabular}{|l|p{8cm}|}
 %     \hline
-%     \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Heuristic \nextheur\ (Dominion Finding Iteration)} \\ \hline\hline
-%     \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & O.~Friedmann \\ \hline
-% %    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{lange-gdv05} \\ \hline
-%     \rule[-8mm]{0mm}{13mm}{\bf Short description} & tries to find dominions by selecting a random strategy and if not computes a counter strategy which is subsequently used\\ \hline
-% %    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & --- \\ \hline
-%     \rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(n)$ \\ \hline
-%     \rule[-3mm]{0mm}{8mm}{\bf Soundness} & yes \\ \hline
-%     \rule[-3mm]{0mm}{8mm}{\bf Completeness} & no \\ \hline
-%     \rule[-3mm]{0mm}{8mm}{\bf Termination} & no \\ \hline
-%     \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & none \\ \hline
+%     \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Heuristic \nextheur\ (Dominion Finding Iteration)} \\ \hline\hline
+%     \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & O.~Friedmann \\ \hline
+% %    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{lange-gdv05} \\ \hline
+%     \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & tries to find dominions by selecting a random strategy and if not computes a counter strategy which is subsequently used\\ \hline
+% %    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & --- \\ \hline
+%     \rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(n)$ \\ \hline
+%     \rule[-3mm]{0mm}{8mm}{\bfseries Soundness} & yes \\ \hline
+%     \rule[-3mm]{0mm}{8mm}{\bfseries Completeness} & no \\ \hline
+%     \rule[-3mm]{0mm}{8mm}{\bfseries Termination} & no \\ \hline
+%     \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & none \\ \hline
 %   \end{tabular}
 % \end{center}
 % }
@@ -85,16 +85,16 @@ strategies. If the winning regions are not empty, the algorithm returns these se
 \begin{center}
   \begin{tabular}{|l|p{8cm}|}
     \hline
-    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Heuristic \nextheur\ (Strategy Guessing Iteration)} \\ \hline\hline
-    \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & O.~Friedmann \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{lange-gdv05} \\ \hline
-    \rule[-8mm]{0mm}{13mm}{\bf Short description} & tries to find dominions by selecting a random strategies\\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & --- \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(n)$ \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Soundness} & yes \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Completeness} & no \\ \hline
-    \rule[-3mm]{0mm}{8mm}{\bf Termination} & no \\ \hline
-%    \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & none \\ \hline
+    \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Heuristic \nextheur\ (Strategy Guessing Iteration)} \\ \hline\hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & O.~Friedmann \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{lange-gdv05} \\ \hline
+    \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & tries to find dominions by selecting a random strategies\\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & --- \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(n)$ \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Soundness} & yes \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Completeness} & no \\ \hline
+    \rule[-3mm]{0mm}{8mm}{\bfseries Termination} & no \\ \hline
+%    \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & none \\ \hline
   \end{tabular}
 \end{center}
 
@@ -112,16 +112,16 @@ strategies. If the winning regions are not empty, the algorithm returns these se
 % \begin{center}
   % \begin{tabular}{|l|p{8cm}|}
     % \hline
-    % \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bf Heuristic \nextheur\ (Reachability Analysis)} \\ \hline\hline
-    % \rule[-3mm]{0mm}{8mm}{\bf Author(s)} & O.~Friedmann\\ \hline
-% %    \rule[-3mm]{0mm}{8mm}{\bf Literature} & \cite{TCS::Zielonka1998} \\ \hline
-    % \rule[-8mm]{0mm}{13mm}{\bf Short description} & Computing reachability sets for both players and all nodes in order to identify specific dominions\\ \hline
-    % \rule[-3mm]{0mm}{8mm}{\bf Time complexity} & $\mathcal{O}(n^2 \cdot d)$ + running time of backend \\ \hline
-    % \rule[-3mm]{0mm}{8mm}{\bf Space complexity} & $\mathcal{O}(n^2)$ + space needed by backend \\ \hline
-    % \rule[-3mm]{0mm}{8mm}{\bf Soundness} & yes \\ \hline
-    % \rule[-3mm]{0mm}{8mm}{\bf Completeness} & no \\ \hline
-    % \rule[-3mm]{0mm}{8mm}{\bf Termination} & yes \\ \hline
-% %    \rule[-3mm]{0mm}{8mm}{\bf Optimisations} & none \\ \hline
+    % \multicolumn{2}{l}{\rule[-3mm]{0mm}{8mm}\quad \bfseries Heuristic \nextheur\ (Reachability Analysis)} \\ \hline\hline
+    % \rule[-3mm]{0mm}{8mm}{\bfseries Author(s)} & O.~Friedmann\\ \hline
+% %    \rule[-3mm]{0mm}{8mm}{\bfseries Literature} & \cite{TCS::Zielonka1998} \\ \hline
+    % \rule[-8mm]{0mm}{13mm}{\bfseries Short description} & Computing reachability sets for both players and all nodes in order to identify specific dominions\\ \hline
+    % \rule[-3mm]{0mm}{8mm}{\bfseries Time complexity} & $\mathcal{O}(n^2 \cdot d)$ + running time of backend \\ \hline
+    % \rule[-3mm]{0mm}{8mm}{\bfseries Space complexity} & $\mathcal{O}(n^2)$ + space needed by backend \\ \hline
+    % \rule[-3mm]{0mm}{8mm}{\bfseries Soundness} & yes \\ \hline
+    % \rule[-3mm]{0mm}{8mm}{\bfseries Completeness} & no \\ \hline
+    % \rule[-3mm]{0mm}{8mm}{\bfseries Termination} & yes \\ \hline
+% %    \rule[-3mm]{0mm}{8mm}{\bfseries Optimisations} & none \\ \hline
   % \end{tabular}
 % \end{center}
 % Note that the information about incompleteness only concerns the heuristic. In combination with a complete

--- a/doc/makros.tex
+++ b/doc/makros.tex
@@ -1,4 +1,5 @@
-\newcommand{\pgsolver}{{\sc PGSolver}\xspace}
+% Kill any active \bfseries etc. with \normalfont to get the old behavior of \sc
+\newcommand{\pgsolver}{{\normalfont\textsc{PGSolver}}\xspace}
 
 \newcommand{\Nat}{\ensuremath{\mathbb{N}}}
 
@@ -10,7 +11,7 @@
 \newcommand{\nextheur}{\stepcounter{heurcounter}\arabic{heurcounter}}
 
 \newcommand{\nonterminal}[1]{\ensuremath{\langle\mathit{#1}\rangle}}
-\newcommand{\terminal}[1]{\ensuremath{{\tt #1}}}
+\newcommand{\terminal}[1]{\ensuremath{\texttt{#1}}}
 \newcommand{\sem}[1]{\ensuremath{[\![ #1 ]\!]}}
 \newcommand{\hide}[1]{}
 

--- a/doc/running.tex
+++ b/doc/running.tex
@@ -35,7 +35,7 @@ one algorithm that should be used for solving. The currently understood command-
    Tells \texttt{pgsolver} to look for the specification of the parity game to solve in the file
    \nonterminal{filename}.
 
-\item[{\tt  -v \nonterminal{level}}] \ \\
+\item[{\ttfamily  -v \nonterminal{level}}] \ \\
    Sets the verbosity level, valid arguments are $0$--$3$, the default is 1. With verbosity level $0$,
    \texttt{pgsolver} will be very humble and not bother \texttt{stdout} with its pathetic goobledigook.
    With verbosity level 1, it will tell you what it does and what the winning regions and strategies
@@ -44,119 +44,119 @@ one algorithm that should be used for solving. The currently understood command-
    SCC structure or priority distribution in the game. Verbosity level 3 is for debugging purposes. Again,
    this very much depends on the solving algorithm.
 
-\item[{\tt --quiet}] \ \\
+\item[{\ttfamily --quiet}] \ \\
    Causes the program to be quiet, same as \texttt{-v 0}.
 
-\item[{\tt --verbose}] \ \\
+\item[{\ttfamily --verbose}] \ \\
    Causes the program to be verbose, same as \texttt{-v 2}.
 
-\item[{\tt --debug}] \ \\
+\item[{\ttfamily --debug}] \ \\
    Causes the program to be very verbose, same as \texttt{-v 3}.
 
-\item[{\tt -d \nonterminal{filename}}] \ \\
+\item[{\ttfamily -d \nonterminal{filename}}] \ \\
    Tells \texttt{pgsolver} to open the file \nonterminal{filename} for writing and print into it the
    \texttt{dot}-code of the parity game as a graph, see also Sect.~\ref{sec:viewing}. If the game has
    been solved during this invocation then the graphical presentation will display the winning regions
    and strategies. You can use option \texttt{-n} in combination with this one to display a pure parity
    game, i.e.\ without the winning information.
 
-% \item[{\tt -f}] \ \\
+% \item[{\ttfamily -f}] \ \\
 %    Causes \texttt{pgsolver} to print the whole game on \texttt{stdout} again. The format is the one
 %    that \texttt{pgsolver} would expect as input.\TODO{Hat das einen besonderen Sinn?}
 
-% \item[{\tt --sanitycheck}]  \enspace or {\tt -sc} \\
+% \item[{\ttfamily --sanitycheck}]  \enspace or {\ttfamily -sc} \\
 %   Checks whether the given parity game is well-formed, meaning that it particularly does not contain any edge leading to inaccessible nodes.
 
-\item[{\tt -n}] \ \\
+\item[{\ttfamily -n}] \ \\
    Tells \texttt{pgsolver} to suppress solving. This can be used to simply draw a parity game in
    \texttt{dot}-format without the information about winning regions and strategies. This is a default
    selection, i.e.\ \pgsolver will not solve a game unless you specify explicitly which algorithm it
    should use. See below for the command-line parameters that let you do so.
 
-\item[{\tt --disableglobalopt}]  \enspace or {\tt -dgo} \\
+\item[{\ttfamily --disableglobalopt}]  \enspace or {\ttfamily -dgo} \\
    Tells \texttt{pgsolver} to completely disable any global optimisations. Global optimisation is enabled by default.
 
-\item[{\tt --disableuselesscycles}]  \enspace or {\tt -dul} \\
+\item[{\ttfamily --disableuselesscycles}]  \enspace or {\ttfamily -dul} \\
    Tells \texttt{pgsolver} to disable to automatic deletion of useless self cycles. This is a global optimisation and is enabled by default.
 
-\item[{\tt --disableusefulcycles}]  \enspace or {\tt -duf} \\
+\item[{\ttfamily --disableusefulcycles}]  \enspace or {\ttfamily -duf} \\
    Tells \texttt{pgsolver} to disablee the automatic utilisation of useful self cycles. This is a global optimisation and is enabled by default.
 
-\item[{\tt --disablesccdecomposition}]  \enspace or {\tt -dsd} \\
+\item[{\ttfamily --disablesccdecomposition}]  \enspace or {\ttfamily -dsd} \\
    Tells \texttt{pgsolver} to decompose the game into strongly connected components. This is enabled by default.
 
-\item[{\tt --disablelocalopt}]  \enspace or {\tt -dlo} \\
+\item[{\ttfamily --disablelocalopt}]  \enspace or {\ttfamily -dlo} \\
    Tells \texttt{pgsolver} to completely disable any local optimisations. Local optimisation is enabled by default.
 
-\item[{\tt --enableprioprop}]  \enspace or {\tt -pp} \\
+\item[{\ttfamily --enableprioprop}]  \enspace or {\ttfamily -pp} \\
    Tells \texttt{pgsolver} to enable priority propagation. This is a local optimisation and is disabled (!) by default.
 
-\item[{\tt --disablepriocomp}]  \enspace or {\tt -dcp} \\
+\item[{\ttfamily --disablepriocomp}]  \enspace or {\ttfamily -dcp} \\
    Tells \texttt{pgsolver} to disable priority compression. This is a local optimisation and is enabled by default.
 
-\item[{\tt --disablespecialgames}]  \enspace or {\tt -dsg} \\
+\item[{\ttfamily --disablespecialgames}]  \enspace or {\ttfamily -dsg} \\
    Tells \texttt{pgsolver} to completely disable any algorithms solving special instances. This is enabled by default.
 
-\item[{\tt --disablesingleparity}]  \enspace or {\tt -dpa} \\
+\item[{\ttfamily --disablesingleparity}]  \enspace or {\ttfamily -dpa} \\
    Tells \texttt{pgsolver} to disable the automatic solving of single parity instances. This is a special instance solving optimisation and is enabled by default.
 
-\item[{\tt --disablesingleplayer}]  \enspace or {\tt -dpl} \\
+\item[{\ttfamily --disablesingleplayer}]  \enspace or {\ttfamily -dpl} \\
    Tells \texttt{pgsolver} to disable the automatic solving of single player instances. This is a special instance solving optimisation and is enabled by default.
 
-\item[{\tt --verify}]  \enspace or {\tt -ve} \\
+\item[{\ttfamily --verify}]  \enspace or {\ttfamily -ve} \\
    This causes \texttt{pgsolver} to perform, after solving, an additional check that the reported winning
    strategies are correct; useful for finding bugs in new algorithm implementations.
 
-\item[{\tt --verify2}]  \enspace or {\tt -ve} \\
-   Same as {\tt --verify} but use a different verification method; useful for finding bugs in new
+\item[{\ttfamily --verify2}]  \enspace or {\ttfamily -ve} \\
+   Same as {\ttfamily --verify} but use a different verification method; useful for finding bugs in new
    algorithm implementations if you have used \texttt{--verify} but want to be really sure.
 
-\item[{\tt --verify3}]  \enspace or {\tt -ve} \\
-   Still the same as {\tt --verify} or {\tt --verify2} but uses yet again a different verification method;
+\item[{\ttfamily --verify3}]  \enspace or {\ttfamily -ve} \\
+   Still the same as {\ttfamily --verify} or {\ttfamily --verify2} but uses yet again a different verification method;
    useful for finding bugs in new algorithm implementations if you have used \texttt{--verify} and
    \texttt{--verify2} but generally have issues with trust.
 
-\item[{\tt --justheatCPU}] \enspace or {\tt -jh}  \\
+\item[{\ttfamily --justheatCPU}] \enspace or {\ttfamily -jh}  \\
    On large parity games, printing the winning information can take a long time because of the bottleneck
    \texttt{stdout}. This option turns the printing of that information off. Useful if one is interested in
    running times only for instance.
 
-\item[{\tt --changesat \nonterminal{satsolver}}] \enspace or {\tt -cs \nonterminal{satsolver}}  \\
+\item[{\ttfamily --changesat \nonterminal{satsolver}}] \enspace or {\ttfamily -cs \nonterminal{satsolver}}  \\
    Selects the SAT solver backend that is to be used. Only affects parity game solving algorithms that
    depend on SAT solving. If there are less than two SAT solvers linked into \pgsolver, this parameter
    is disabled.
 
-\item[{\tt --viasat}] \enspace or {\tt -vs} \\
+\item[{\ttfamily --viasat}] \enspace or {\ttfamily -vs} \\
    Use the small progress measure encoding for propositional logic and a reduction to SAT due to Lange.
    Also see the command-line parameters that select the SAT solver to be used.
    This parameter is only available if there is at least one SAT solver linked into \pgsolver.
 
-\item[{\tt --stratimprove}] \enspace or {\tt -si} \\
+\item[{\ttfamily --stratimprove}] \enspace or {\ttfamily -si} \\
    Use the strategy improvement algorithm due to Jurdzi{\'n}ski and V\"oge.
 
-\item[{\tt  --optstratimprov}] \enspace or {\tt -os} \\
+\item[{\ttfamily  --optstratimprov}] \enspace or {\ttfamily -os} \\
    Use the strategy improvement algorithm due to Schewe.
 
-\item[{\tt --smallprog}] \enspace or {\tt -sp} \\
+\item[{\ttfamily --smallprog}] \enspace or {\ttfamily -sp} \\
    Use the small progress measure algorithm due to Jurdzi{\'n}ski.
 
-\item[{\tt --satsolve}] \enspace or {\tt -ss} \\
+\item[{\ttfamily --satsolve}] \enspace or {\ttfamily -ss} \\
    Tells \texttt{pgsolver} to encode a direct NP predicate that is to be solved due To Friedmann.
    This parameter is only available if there is at least one SAT solver linked into \pgsolver.
 
-\item[{\tt --recursive}] \enspace or {\tt -re} \\
+\item[{\ttfamily --recursive}] \enspace or {\ttfamily -re} \\
    Use the recursive algorithm due to Zielonka.
 
-\item[{\tt --modelchecker}] \enspace or {\tt -mc}  \\
+\item[{\ttfamily --modelchecker}] \enspace or {\ttfamily -mc}  \\
    Use the $\mu$-calculus model checker due to Stevens and Stirling.
 
-\item[{\tt --dominiondec}] \enspace or {\tt -dd} \\
+\item[{\ttfamily --dominiondec}] \enspace or {\ttfamily -dd} \\
    Use the dominion decomposition algorithm due to Jurdzi{\'n}ski, Paterson, and Zwick.
 
-\item[{\tt --bigstep}] \enspace or {\tt -bs} \\
+\item[{\ttfamily --bigstep}] \enspace or {\ttfamily -bs} \\
    Use the big-step procedure due to Schewe.
 
-\item[{\tt --guessstrategy}] \enspace or {\tt -gs} \\
+\item[{\ttfamily --guessstrategy}] \enspace or {\ttfamily -gs} \\
    Use the strategy guessing heuristic.
 
 \end{description}

--- a/doc/specs.tex
+++ b/doc/specs.tex
@@ -18,8 +18,8 @@ name of the node. The format can easily be described in EBNF.
 \nonterminal{owner} \enspace &::= \enspace \terminal{0} \mid \terminal{1} \\[2mm]
 \nonterminal{successors} \enspace &::= \enspace \nonterminal{identifier}\enspace
   (\terminal{,}\enspace \nonterminal{identifier})^* \\[2mm]
-\nonterminal{name} \enspace &::= \enspace \mbox{{\tt "}}\enspace
-  (\mbox{ any ASCII string not containing `{\tt "}'}) \enspace \mbox{{\tt "}}
+\nonterminal{name} \enspace &::= \enspace \texttt{"}\enspace
+  (\mbox{ any ASCII string not containing `{\texttt{"}}'}) \enspace \texttt{"}
 \end{align*}
 There must be whitespace characters between the following pairs of tokens:
 \nonterminal{identifier} and \nonterminal{priority}, \nonterminal{priority} and \nonterminal{owner},

--- a/doc/tools.tex
+++ b/doc/tools.tex
@@ -55,10 +55,10 @@ It takes a parity game on \texttt{stdin} in the specification format described a
 and returns the permuted game on \texttt{stdout}. The currently understood command-line
 parameters are:
 \begin{description}
-\item[{\tt --disablenodeobfuscation}] \enspace or {\tt -dn} \\
+\item[{\ttfamily --disablenodeobfuscation}] \enspace or {\ttfamily -dn} \\
 	Disables the obfuscation of the ordering of nodes.
 
-\item[{\tt --disableedgeobfuscation}] \enspace or {\tt -de} \\
+\item[{\ttfamily --disableedgeobfuscation}] \enspace or {\ttfamily -de} \\
     Disables the obfuscation of the ordering of the edges.
 \end{description}
 
@@ -130,11 +130,11 @@ understood command-line parameters are:
    Tells the tool to look for the specification of the parity game to transform in the file
    \nonterminal{filename}.
 
-\item[{\tt --priorities}] \enspace or {\tt -pr} \\
+\item[{\ttfamily --priorities}] \enspace or {\ttfamily -pr} \\
     It reduces the priority of each node preserving their parities as well as the relation $\le$
     among priorities of nodes within an SCC of the game graph.
 
-\item[{\tt --priopropagation}] \enspace or {\tt -pp} \\
+\item[{\ttfamily --priopropagation}] \enspace or {\ttfamily -pp} \\
     It tries to reduce the overall number of priorities occurring in the game by pushing priorities
     along edges of the game graph overriding smaller ones. If all nodes leading to a node $v$ have a
     greater priority than the node itself, the priority of this node is altered to the least predecessing
@@ -144,27 +144,27 @@ understood command-line parameters are:
     Obviously, this process may destroy the preservation of parities and the less-or-equals relation among
     priorites described above.
 
-\item[{\tt --antipropagation}] \enspace or {\tt -ap} \\
+\item[{\ttfamily --antipropagation}] \enspace or {\ttfamily -ap} \\
 	It tries to set the priority of as many nodes as possible to zero. If all nodes leading to a node
 	$v$ have a greater priority than the node itself, the priority of this node can be set to zero.
 	Similarly the priority of a node is adapted if all successors of a node have a greater priority than
 	the node itself. This process is iterated until stability is reached.
 
-\item[{\tt  --fakealt}] \enspace or {\tt -fa} \\
+\item[{\ttfamily  --fakealt}] \enspace or {\ttfamily -fa} \\
     Keep fake alternation w.r.t.\ priorities. If this option is enabled the compaction of priorities
     never assigns the same priority to nodes that had different priorities before, even if there is
     no other priority occurring inbetween and both priorities in question are of the same parity.
 
-\item[{\tt --wholegame}] \enspace or {\tt -pp} \\
+\item[{\ttfamily --wholegame}] \enspace or {\ttfamily -pp} \\
     The compression of priorities is usually done independently for each SCC of the game graph.
     This switch causes the graph's SCC decomposition to be ignored. This will in general result
     in a worse compression rate.
 
-\item[{\tt --nodes}] \enspace or {\tt -no} \\
+\item[{\ttfamily --nodes}] \enspace or {\ttfamily -no} \\
     Performs a compression of the space of identifiers of a parity game, resulting in a possible
     down-shift of identifiers.
 
-\item[{\tt --minmaxswap}] \enspace or {\tt -mm} \\
+\item[{\ttfamily --minmaxswap}] \enspace or {\ttfamily -mm} \\
     Transforms a min-parity game into a max-parity one and vice versa.
 \end{description}
 
@@ -271,40 +271,40 @@ and returns the transformed game on \texttt{stdout}. The currently understood co
    Tells the tool to look for the specification of the parity game to transform in the file
    \nonterminal{filename}.
 
-\item[{\tt --total}] \enspace or {\tt -to} \\
+\item[{\ttfamily --total}] \enspace or {\ttfamily -to} \\
    Perform a totality transformation on the given parity game.
 
-\item[{\tt --alternating}] \enspace or {\tt -al} \\
+\item[{\ttfamily --alternating}] \enspace or {\ttfamily -al} \\
    Perform a choice-alternation transformation on the given parity game.
 
- \item[{\tt --singlescc}] \enspace or {\tt -scc} \\
+ \item[{\ttfamily --singlescc}] \enspace or {\ttfamily -scc} \\
    Perform a simple transformation that results in a single-scc-parity game. The winning sets and
    strategies of the original game and the transformed game match.
 
- \item[{\tt --prioalignment}] \enspace or {\tt -pa} \\
+ \item[{\ttfamily --prioalignment}] \enspace or {\ttfamily -pa} \\
    Performs a transformation s.t.\ the parity of each node of the resulting game matches its player
    unless its priority is zero.
 
-\item[{\tt --dummynodes}] \enspace or {\tt -dn} \\
+\item[{\ttfamily --dummynodes}] \enspace or {\ttfamily -dn} \\
    Performs a transformation that divides each edge by an additional node with priority $0$.
 
-\item[{\tt --uniquizeprios}] \enspace or {\tt -up} \\
+\item[{\ttfamily --uniquizeprios}] \enspace or {\ttfamily -up} \\
    Performs a transformation of the occurring priorities s.t.\ every occurring priority occurs only once.
 
- \item[{\tt --cheapescapecycles}] \enspace or {\tt -ce} \\
+ \item[{\ttfamily --cheapescapecycles}] \enspace or {\ttfamily -ce} \\
    Adds two low-priority cycles $c_0$ and $c_1$ to the game that are profitable for either one of the
    player ($c_0$ for player $0$ and $c_1$ for player $1$). All nodes in the original belonging to
    player $0$ get additional edges leading to $c_1$ and all nodes belonging to player $1$ get
    additional edges leading to $c_0$.
 
-\item[{\tt --bouncingnode}] \enspace or {\tt -bn} \\
+\item[{\ttfamily --bouncingnode}] \enspace or {\ttfamily -bn} \\
    Replaces every self-cycle by a bouncing node.
 
- \item[{\tt --increasepriorityoccurrence}] \enspace or {\tt -ip} \\
+ \item[{\ttfamily --increasepriorityoccurrence}] \enspace or {\ttfamily -ip} \\
    Increases the occurrence of all priorities by one by simply inserting a long cycle that is not
    connected to the rest of the game.
 
-\item[{\tt --antiprioritycompactation}] \enspace or {\tt -ap} \\
+\item[{\ttfamily --antiprioritycompactation}] \enspace or {\ttfamily -ap} \\
    Adds additional nodes that prohibits any priority compactation.
 \end{description}
 
@@ -361,27 +361,27 @@ from files, and carries out the benchmark. The currently understood command-line
    Tells the tool to look for the specification of the parity game in the file
    \nonterminal{filename}.
 
-\item[{\tt --\nonterminal{solver} `solver options`}] \ \\
+\item[{\ttfamily --\nonterminal{solver} `solver options`}] \ \\
    Benchmark the specified solver. All solvers that are compiled into \pgsolver are available here. Note: even if you don't want to pass any options to the solver, you still need to add ``.
 
-\item[{\tt --silent}] \enspace or {\tt -s} \\
+\item[{\ttfamily --silent}] \enspace or {\ttfamily -s} \\
    Only print the final statistics on \texttt{stdout}.
 
-\item[{\tt --gnuplotformat}] \enspace or {\tt -gp} \\
+\item[{\ttfamily --gnuplotformat}] \enspace or {\ttfamily -gp} \\
    Only print a gnuplot-compatible line.
 
- \item[{\tt --timeout \nonterminal{timeout}}] \enspace or {\tt -to \nonterminal{timeout}} \\
+ \item[{\ttfamily --timeout \nonterminal{timeout}}] \enspace or {\ttfamily -to \nonterminal{timeout}} \\
    If one of the solvers requires more than $t$ seconds on one of the test cases, the solver is ignored
    for the rest of the series. There is no timeout by default.
 
-\item[{\tt --name \nonterminal{title}}] \enspace or {\tt -n \nonterminal{title}} \\
+\item[{\ttfamily --name \nonterminal{title}}] \enspace or {\ttfamily -n \nonterminal{title}} \\
    Specifies the title of the benchmark that is to be printed in the final statistics.
 
- \item[{\tt --times \nonterminal{n}}] \enspace or {\tt -t \nonterminal{n}} \\
+ \item[{\ttfamily --times \nonterminal{n}}] \enspace or {\ttfamily -t \nonterminal{n}} \\
    Specifies the number of iterations a single test case is carried out per algorithm. By default, $n$
    is 10.
 
-\item[{\tt --\nonterminal{optimisation-option}}] \ \\
+\item[{\ttfamily --\nonterminal{optimisation-option}}] \ \\
    All optimisation options that are available to \texttt{pgsolver} are also available here.
 \end{description}
 


### PR DESCRIPTION
Recent versions of komascript (in particular, the version bundled with texlive 2016) do not accept `\sc`, `\tt` and `\bf`.  So compiling the documentation with pdflatex fails.

This commit replaces these with the more modern versions `\scshape`, `\ttfamily` and `\bfseries`.