### PR TITLE
add solver: succinct small progress measures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ doc/main.thm
 doc/main.toc
 .paths
 _build
+.idea
 *.native
 temp
 SatConfig

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ all: pgsolver generators tools test
 include satsolversforocaml/SatCompile
 
 pgsolver: generatesat
-	ocamlbuild $(SATFLAGS) -libs $(LIBS) main.native
+	ocamlbuild $(SATFLAGS) -libs $(LIBS) -package extlib main.native
 	mv main.native bin/pgsolver
 
 test: generatesat
-	ocamlbuild $(SATFLAGS) -libs $(LIBS) -package oUnit solverstest.native
+	ocamlbuild $(SATFLAGS) -libs $(LIBS) -package oUnit -package extlib solverstest.native
 	mv solverstest.native bin/ounit
 
 
@@ -35,7 +35,7 @@ generators: randomgame.gen laddergame.gen clusteredrandomgame.gen cliquegame.gen
 tools: auso.tool benchmark.tool benchstratimpr.tool combine.tool complexdecomp.tool compressor.tool fullimprarena.tool imprarena.tool infotool.tool obfuscator.tool policyitervis.tool transformer.tool winningstrats.tool itersat.tool
 
 %.tool: generatesat
-	ocamlbuild $(SATFLAGS) -libs $(LIBS) $*.native
+	ocamlbuild $(SATFLAGS) -libs $(LIBS) -package extlib $*.native
 	mv $*.native bin/$*
 
 

--- a/src/paritygame/paritygamebitset.ml
+++ b/src/paritygame/paritygamebitset.ml
@@ -1,0 +1,101 @@
+open Basics;;
+open Paritygame;;
+
+let is_empty_bset bset length =
+	let i = ref 0 in
+	let empty = ref true in
+	while !i < length && !empty do
+	  if BitSet.is_set bset !i
+	  then empty := false
+	  else incr i;
+	done;
+	!empty;;
+
+let bit_dom_array_bound array length bound =
+	let dom = BitSet.create length in
+	for i = 0 to length - 1 do
+	  if array.(i) > bound
+	  then BitSet.set dom i
+	done;
+	dom;;
+
+let collect_nodes_bit game length =
+  let bset = BitSet.create length in
+  for i = 0 to length - 1 do
+    if pg_isDefined game i
+    then BitSet.set bset i
+  done;
+  bset;;
+
+let pre_bit game pre subgame_vr player target length =
+	for i = 0 to length - 1 do
+	  if BitSet.is_set subgame_vr i
+	  then (
+      let pl = pg_get_owner game i in
+      let ws = pg_get_successors game i in
+      let take = ref false in
+      if pl = player
+      then take := ns_fold (fun b -> fun w -> b || (BitSet.is_set target w)) false ws
+      else (
+        if pl != plr_undef
+        then (
+          take := true;
+          ns_iter (fun v ->
+                    if (BitSet.is_set subgame_vr v) && not (BitSet.is_set target v)
+                    then take := false
+                  ) ws;
+        );
+      );
+      if !take then BitSet.set pre i else BitSet.unset pre i;
+	  );
+	done;;
+
+let attr_bit game game_vr todoS todoQ strategy player region region_en =
+  let attr = BitSet.copy region in
+  let used = BitSet.copy region in
+  Enum.iter (fun v ->
+              ns_iter (fun w -> if not (BitSet.is_set used w)
+                then (
+                  let pl = pg_get_owner game w in
+                  BitSet.set used w;
+                  if pl<>player
+                  then Queue.add w todoQ
+                  else (Queue.add w todoS; strategy.(w) <- v;)
+                );
+              ) (ns_filter (fun w -> BitSet.is_set game_vr w) (pg_get_predecessors game v))
+            ) region_en;
+  while not (Queue.is_empty todoS && Queue.is_empty todoQ) do
+    if not (Queue.is_empty todoS)
+    then (
+      let v = Queue.take todoS in
+      BitSet.set attr v;
+      ns_iter (fun w -> if not (BitSet.is_set used w)
+        then (
+          let pl = pg_get_owner game w in
+          BitSet.set used w;
+          if pl<>player
+          then Queue.add w todoQ
+          else (Queue.add w todoS; strategy.(w) <- v;)
+        );
+      ) (ns_filter (fun w -> BitSet.is_set game_vr w) (pg_get_predecessors game v));
+    )
+    else (
+      let v = Queue.take todoQ in
+      let ws = pg_get_successors game v in
+      if ns_fold (fun b w -> b && (if BitSet.is_set game_vr w then BitSet.is_set attr w else true)) true ws
+      then (
+        BitSet.set attr v;
+        ns_iter (fun w -> if not (BitSet.is_set used w)
+          then (
+            let pl = pg_get_owner game w in
+            BitSet.set used w;
+            if pl<>player
+            then Queue.add w todoQ
+            else (Queue.add w todoS; strategy.(w) <- v;)
+          );
+        ) (ns_filter (fun w -> BitSet.is_set game_vr w) (pg_get_predecessors game v));
+      )
+      else BitSet.unset used v;
+    );
+  done;
+  attr;;

--- a/src/paritygame/paritygamebitset.mli
+++ b/src/paritygame/paritygamebitset.mli
@@ -1,0 +1,11 @@
+open Paritygame
+
+(**************************************************************
+ * Priority Promotion Approach Definitions                    *
+ **************************************************************)
+
+val is_empty_bset : BitSet.t -> int -> bool
+val bit_dom_array_bound : int array -> int -> int -> BitSet.t
+val collect_nodes_bit : paritygame -> int -> BitSet.t
+val pre_bit : paritygame -> BitSet.t -> BitSet.t -> player -> BitSet.t -> int -> unit
+val attr_bit : paritygame -> BitSet.t -> int Queue.t -> int Queue.t -> strategy -> player -> BitSet.t -> int Enum.t -> BitSet.t

--- a/src/paritygame/solverlist.ml
+++ b/src/paritygame/solverlist.ml
@@ -7,6 +7,7 @@ include Localmodelchecker;;
 include Optstratimprov;;
 include Recursive;;
 include Smallprogress;;
+include Succinctsmallprogress;;
 include Stratimpralgs;;
 include Stratimprlocal;;
 include Stratimprlocal2;;

--- a/src/paritygame/solverlist.ml
+++ b/src/paritygame/solverlist.ml
@@ -23,4 +23,8 @@ include Stratimprdisc;;
 include Viasat;;
 include Satsolve;;
 include Stratimprsat;;
+include Prioprom;;
+include Priopromplus;;
+include Priopromdelay;;
+include Priopromrecovery;;
 (*include Smtsolve;;*)

--- a/src/solvers/prioprom.ml
+++ b/src/solvers/prioprom.ml
@@ -1,0 +1,238 @@
+
+(*******************************************************************************
+ *                                                                             *
+ * The Priority Promotion Procedure                                            *
+ *                                                                             *
+ * from:                                                                       *
+ * M. Benerecetti, D. Dell'Erba, and F. Mogavero.                              *
+ * Solving Parity Games via Priority Promotion,                                *
+ * CAV 2016, LNCS 9780 (Part II), Springer, pp. 270-290, 2016.                 *
+ *                                                                             *
+ ******************************************************************************)
+
+open Basics;;
+open Paritygame;;
+open Univsolve;;
+open Paritygamebitset;;
+open Solvers;;
+
+let query game region r p player was_open att_qP att_qO subgame_vr reg_strategy vr l =
+  let r_dom = bit_dom_array_bound r l p in
+  if was_open = 1
+  then BitSet.differentiate subgame_vr !region
+  else (
+    for i = 0 to l - 1 do
+      if (BitSet.is_set vr i) && not (BitSet.is_set r_dom i)
+      then BitSet.set subgame_vr i
+      else BitSet.unset subgame_vr i
+    done;
+  );
+  player := plr_benefits p;
+  let target = BitSet.create l in
+  for i = 0 to l - 1 do
+    reg_strategy.(i) <- -1;
+    if r.(i) = p
+    then BitSet.set target i
+  done;
+  let reg_en = BitSet.enum target in
+  region := attr_bit game subgame_vr att_qP att_qO reg_strategy !player target (Enum.clone reg_en);
+  (target,reg_en,BitSet.enum r_dom);;
+
+let dispatcher game region r player pre r_enum target target_enum max_col r_strategy subgame_vr reg_strategy vr l =
+  let pre_set = BitSet.diff vr region in
+  Enum.iter (fun v -> BitSet.unset pre_set v) (Enum.clone r_enum);
+  Enum.iter (fun i ->
+      let pl = pg_get_owner game i in
+      let ws = pg_get_successors game i in
+      if pl = player
+      then (
+        if r_strategy.(i) = -1
+        then (
+          let w = ns_fold (fun b -> fun w -> if (b > -1 || not (BitSet.is_set vr w) || not (BitSet.is_set region w)) then b else w) (-1) ws in
+          if w > -1 then reg_strategy.(i) <- w;
+        )
+        else reg_strategy.(i) <- r_strategy.(i);
+      )
+    ) target_enum;
+  pre_bit game pre subgame_vr (plr_opponent player) pre_set l;
+  if not (is_empty_bset (BitSet.inter pre target) l)
+  then 1
+  else (
+    let r_pl = BitSet.create l in
+    if player = plr_Even
+    then Enum.iter (fun i -> if r.(i) mod 2 = 0 then BitSet.set r_pl i) r_enum
+    else Enum.iter (fun i -> if r.(i) mod 2 = 1 then BitSet.set r_pl i) r_enum;
+    let min = ref (max_col) in
+    Enum.iter (fun v ->
+        let ws = pg_get_successors game v in
+        let color = ref (max_col) in
+        ns_iter (fun w -> if BitSet.is_set vr w && BitSet.is_set r_pl w
+                  then (
+                    if r.(w) < !color
+                    then (
+                      color := r.(w);
+                      if r.(w) < !min
+                      then min := r.(w);
+                    )
+                  );
+                ) ws;
+      ) (BitSet.enum region);
+    if !min <> (max_col)
+    then !min
+    else 0;
+  );;
+
+let successor game region r p action r_strategy reg_strategy vr l =
+  if action = 1
+  then (
+    let new_p = ref 0 in
+    for i = 0 to l - 1 do
+      if BitSet.is_set region i
+      then r.(i) <- !p;
+      if reg_strategy.(i) <> -1
+      then r_strategy.(i) <- reg_strategy.(i);
+      if r.(i) < !p && r.(i) > !new_p
+      then new_p := r.(i);
+    done;
+    p := !new_p;
+  )
+  else (
+    p := action;
+    for i = 0 to l - 1 do
+      if BitSet.is_set region i
+      then r.(i) <- !p
+      else (
+        if r.(i) < !p && BitSet.is_set vr i
+        then (
+          let pr = pg_get_priority game i in
+          r.(i) <- pr;
+          r_strategy.(i) <- -1;
+        );
+      );
+      if reg_strategy.(i) <> -1
+      then r_strategy.(i) <- reg_strategy.(i);
+    done;
+  );;
+
+let search game =
+  let tot_query = ref 0 in
+  let tot_promo = ref 0 in
+  let queries = ref 0 in
+  let promo = ref 0 in
+  let max_query = ref 0 in
+  let max_promo = ref 0 in
+  let wr_count = ref 0 in
+  let l = pg_size game in
+  let reg_strategy = Array.make l (-1) in
+  let r_strategy = Array.make l (-1) in
+  let solution = sol_create game in
+  let str_out = Array.make l (-1) in
+  let empty = ref false in
+  let p = ref (-1) in
+  let r = Array.make l (-1) in
+  let region = ref (BitSet.create l) in
+  let vr = collect_nodes_bit game l in
+  let subgame_vr = BitSet.copy vr in
+  let node_count = ref 0 in
+  let pre = BitSet.create l in
+  let att_qP = Queue.create () in
+  let att_qO = Queue.create () in
+  let action = ref 0 in
+  let player = ref plr_undef in
+  for i = 0 to l - 1 do
+    if BitSet.is_set vr i
+    then (
+      incr node_count;
+      let pr = pg_get_priority game i in
+      r.(i) <- pr;
+      if pr > !p then p := pr;
+    );
+  done;
+  let max_col = ref (1 + !p) in
+  while not !empty do
+    incr tot_query;
+    incr queries;
+    let (target',tar_en',rd_en') = query game region r !p player !action att_qP att_qO subgame_vr reg_strategy vr l in
+    action := dispatcher game !region r !player pre rd_en' target' tar_en' !max_col r_strategy subgame_vr reg_strategy vr l;
+    while !action <> 0 do
+      incr tot_query;
+      incr queries;
+      if !action > 1
+      then (
+        incr tot_promo;
+        incr promo;
+      );
+      successor game !region r p !action r_strategy reg_strategy vr l;
+      let (target,tar_en,rd_en) = query game region r !p player !action att_qP att_qO subgame_vr reg_strategy vr l in
+      action := dispatcher game !region r !player pre rd_en target tar_en !max_col r_strategy subgame_vr reg_strategy vr l;
+    done;
+    if !promo > !max_promo
+    then max_promo := !promo;
+    if !queries > !max_query
+    then max_query := !queries;
+    incr wr_count;
+    if BitSet.count !region = !node_count
+    then (
+      empty := true;
+      for i = 0 to l - 1 do
+        if reg_strategy.(i) <> -1
+        then str_out.(i) <- reg_strategy.(i);
+        if BitSet.is_set !region i
+        then sol_set solution i !player;
+      done;
+    )
+    else (
+      let region' = attr_bit game vr att_qP att_qO reg_strategy !player !region (BitSet.enum !region) in
+      node_count := 0;
+      empty := true;
+      p := 0;
+      action := 0;
+      for i = 0 to l - 1 do
+        if reg_strategy.(i) <> -1
+        then str_out.(i) <- reg_strategy.(i);
+        if BitSet.is_set region' i
+        then solution.(i) <- !player;
+        r_strategy.(i) <- -1;
+        if solution.(i) = plr_undef && BitSet.is_set vr i
+        then (
+          incr node_count;
+          empty := false;
+          let pr = pg_get_priority game i in
+          r.(i) <- pr;
+          if pr > !p then p := pr;
+          BitSet.set subgame_vr i;
+        )
+        else (
+          r.(i) <- -1;
+          BitSet.unset vr i;
+          BitSet.unset subgame_vr i;
+        );
+      done;
+      player := plr_undef;
+      max_col := 1 + !p;
+      promo := 0;
+      queries := 0;
+    );
+  done;
+  (solution,str_out,!tot_query,!tot_promo,!max_query,!max_promo,!wr_count);;
+
+let ppsolve game =
+  let msg_tagged v = message_autotagged v (fun _ -> "PP") in
+  let (solution,strategy,queries,proms,maxq,maxp,wr) = search game in
+  msg_tagged 2 (fun _ -> "\n");
+  msg_tagged 2 (fun _ -> "Total number of queries: " ^ string_of_int queries ^ "\n");
+  msg_tagged 2 (fun _ -> "Total number of promotions: " ^ string_of_int proms ^ "\n");
+  msg_tagged 2 (fun _ -> "Maximum number of queries: " ^ string_of_int maxq ^ "\n");
+  msg_tagged 2 (fun _ -> "Maximum number of promotions: " ^ string_of_int maxp ^ "\n");
+  msg_tagged 2 (fun _ -> "Number of dominions: " ^ string_of_int wr ^ "\n");
+  (solution,strategy);;
+
+let solve game = ppsolve game;;
+
+register_solver solve "prioprom" "pp" "use the original Priority Promotion procedure";;
+
+let solveuniv game =
+  let opt = (universal_solve_init_options_verbose !universal_solve_global_options) in
+  universal_solve opt ppsolve game;;
+
+register_solver solveuniv "priopromuniv" "ppuniv" "use the original Priority Promotion procedure integrated with the universal solver";;

--- a/src/solvers/prioprom.mli
+++ b/src/solvers/prioprom.mli
@@ -1,0 +1,3 @@
+open Paritygame ;;
+
+val solve : paritygame -> solution * strategy

--- a/src/solvers/priopromdelay.ml
+++ b/src/solvers/priopromdelay.ml
@@ -1,0 +1,332 @@
+
+(*******************************************************************************
+ *                                                                             *
+ * The Delayed Promotion Procedure                                             *
+ *                                                                             *
+ * from:                                                                       *
+ * M. Benerecetti, D. Dell'Erba, and F. Mogavero.                              *
+ * A Delayed Promotion Policy for Parity Games,                                *
+ * GandALF 2016, EPTCS 226, pp. 30-45, 2016                                    *
+ *                                                                             *
+ ******************************************************************************)
+
+open Basics;;
+open Paritygame;;
+open Univsolve;;
+open Solvers;;
+open Paritygamebitset;;
+open FSet;;
+open FMap;;
+
+let not_none = function
+    None -> false
+  |	_ -> true;;
+
+let query game region r p player was_open att_qP att_qO subgame_vr reg_strategy vr l =
+  let r_dom = bit_dom_array_bound r l p in
+  if was_open = 1
+  then BitSet.differentiate subgame_vr !region
+  else (
+    for i = 0 to l - 1 do
+      if (BitSet.is_set vr i) && not (BitSet.is_set r_dom i)
+      then BitSet.set subgame_vr i
+      else BitSet.unset subgame_vr i
+    done;
+  );
+  player := plr_benefits p;
+  let target = BitSet.create l in
+  for i = 0 to l - 1 do
+    reg_strategy.(i) <- -1;
+    if r.(i) = p
+    then BitSet.set target i
+  done;
+  let reg_en = BitSet.enum target in
+  region := attr_bit game subgame_vr att_qP att_qO reg_strategy !player target (Enum.clone reg_en);
+  (target,reg_en,BitSet.enum r_dom);;
+
+let dispatcher game region r p player f max_f delay_even delay_odd even_set odd_set pre r_enum target target_enum max_col r_strategy subgame_vr reg_strategy vr l =
+  let pre_set = BitSet.diff vr region in
+  Enum.iter (fun v -> BitSet.unset pre_set v) (Enum.clone r_enum);
+  Enum.iter (fun i ->
+      let pl = pg_get_owner game i in
+      let ws = pg_get_successors game i in
+      if pl = player
+      then (
+        if r_strategy.(i) = -1
+        then (
+          let w = ns_fold (fun b -> fun w -> if (b > -1 || not (BitSet.is_set vr w) || not (BitSet.is_set region w)) then b else w) (-1) ws in
+          if w > -1 then reg_strategy.(i) <- w;
+        )
+        else reg_strategy.(i) <- r_strategy.(i);
+      )
+    ) target_enum;
+  pre_bit game pre subgame_vr (plr_opponent player) pre_set l;
+  if not (is_empty_bset (BitSet.inter pre target) l)
+  then (
+    Enum.iter(fun i -> f.(i) <- p;) (BitSet.enum region);
+    1
+  )
+  else (
+    let r_pl = BitSet.create l in
+    if player = plr_Even
+    then Enum.iter (fun i -> if r.(i) mod 2 = 0 then BitSet.set r_pl i) r_enum
+    else Enum.iter (fun i -> if r.(i) mod 2 = 1 then BitSet.set r_pl i) r_enum;
+    let min = ref (max_col) in
+    Enum.iter (fun v ->
+        let ws = pg_get_successors game v in
+        ns_iter (fun w -> if BitSet.is_set vr w && BitSet.is_set r_pl w
+                  then (
+                    if f.(w) < !min
+                    then min := f.(w);
+                  )
+                ) ws;
+      ) (BitSet.enum region);
+    if !min <> (max_col)
+    then (
+      let check = ref false in
+      let over = if player = plr_Even
+        then FSet.min_elt odd_set
+        else FSet.min_elt even_set in
+      if over < Some !min && not_none over
+      then check := true;
+      if not !check && (not (FMap.is_empty !delay_even) || not (FMap.is_empty !delay_odd))
+      then (
+        FMap.iter (fun a b -> if not !check && !min >= a && !min <= b then check := true) !delay_even;
+        FMap.iter (fun a b -> if not !check && !min >= a && !min <= b then check := true) !delay_odd;
+      );
+      if !check
+      then (
+        for i = 0 to l - 1 do
+          if BitSet.is_set region i
+          then f.(i) <- !min;
+        done;
+        if !max_f < !min
+        then max_f := !min;
+        if Array.fold_left (fun b -> fun w -> b || w < p && w > -1) false f
+        then (
+          if p mod 2 = 0
+          then delay_even := FMap.add p !min !delay_even
+          else delay_odd := FMap.add p !min !delay_odd;
+          1
+        )
+        else -1;
+      )
+      else (!min;)
+    )
+    else 0;
+  );;
+
+let successor game region r p player action f max_f delay_even delay_odd even_set odd_set r_strategy reg_strategy vr l =
+  if action = 1
+  then (
+    let new_p = ref 0 in
+    for i = 0 to l - 1 do
+      if BitSet.is_set region i
+      then r.(i) <- !p;
+      if reg_strategy.(i) <> -1
+      then r_strategy.(i) <- reg_strategy.(i);
+      if r.(i) < !p && r.(i) > !new_p
+      then new_p := r.(i);
+    done;
+    p := !new_p;
+  )
+  else (
+    if action = -1
+    then (
+      p := !max_f;
+      for i = 0 to l - 1 do
+        if BitSet.is_set vr i && f.(i) < !p && f.(i) mod 2 <> !p mod 2
+        then (
+          let pr = pg_get_priority game i in
+          r_strategy.(i) <- -1;
+          r.(i) <- pr;
+          f.(i) <- pr;
+        )
+        else r.(i) <- f.(i);
+        if reg_strategy.(i) <> -1
+        then r_strategy.(i) <- reg_strategy.(i);
+      done;
+      if !p mod 2 = 0
+      then (
+        FMap.iter (fun _ b -> odd_set := FSet.add b !odd_set) !delay_odd;
+        even_set := FSet.filter (fun a -> a > !p) !even_set;
+      )
+      else (
+        FMap.iter (fun _ b -> even_set := FSet.add b !even_set) !delay_even;
+        odd_set := FSet.filter (fun a -> a > !p) !odd_set;
+      );
+      delay_odd := FMap.empty;
+      delay_even := FMap.empty;
+      max_f := 0;
+    )
+    else (
+      let old_p = !p in
+      p := action;
+      for i = 0 to l - 1 do
+        if BitSet.is_set region i
+        then (
+          r.(i) <- !p;
+          f.(i) <- !p;
+        )
+        else (
+          if BitSet.is_set vr i && r.(i) < !p && plr_benefits r.(i) <> player
+          then (
+            let pr = pg_get_priority game i in
+            r.(i) <- pr;
+            f.(i) <- pr;
+            r_strategy.(i) <- -1;
+          );
+        );
+        if reg_strategy.(i) <> -1
+        then r_strategy.(i) <- reg_strategy.(i);
+      done;
+      if player = plr_Even
+      then (
+        even_set := FSet.remove old_p !even_set;
+        even_set := FSet.add !p !even_set
+      )
+      else (
+        odd_set := FSet.remove old_p !odd_set;
+        odd_set := FSet.add !p !odd_set
+      );
+      if !max_f < !p
+      then max_f := 0;
+    );
+  );;
+
+let search game =
+  let tot_query = ref 0 in
+  let tot_promo = ref 0 in
+  let queries = ref 0 in
+  let promo = ref 0 in
+  let max_query = ref 0 in
+  let max_promo = ref 0 in
+  let wr_count = ref 0 in
+  let l = pg_size game in
+  let reg_strategy = Array.make l (-1) in
+  let r_strategy = Array.make l (-1) in
+  let solution = sol_create game in
+  let str_out = Array.make l (-1) in
+  let empty = ref false in
+  let p = ref (-1) in
+  let r = Array.make l (-1) in
+  let region = ref (BitSet.create l) in
+  let vr = collect_nodes_bit game l in
+  let subgame_vr = BitSet.copy vr in
+  let node_count = ref 0 in
+  let pre = BitSet.create l in
+  let att_qP = Queue.create () in
+  let att_qO = Queue.create () in
+  let action = ref 0 in
+  let player = ref plr_undef in
+  let f = Array.make l (-1) in
+  let max_f = ref 0 in
+  let even_set = ref FSet.empty in
+  let odd_set = ref FSet.empty in
+  let delay_even = ref FMap.empty in
+  let delay_odd = ref FMap.empty in
+  for i = 0 to l - 1 do
+    if BitSet.is_set vr i
+    then (
+      incr node_count;
+      let pr = pg_get_priority game i in
+      r.(i) <- pr;
+      f.(i) <- pr;
+      if pr > !p then p := pr;
+    );
+  done;
+  let max_col = ref (1 + !p) in
+  while not !empty do
+    incr tot_query;
+    incr queries;
+    let (target',tar_en',rd_en') = query game region r !p player !action att_qP att_qO subgame_vr reg_strategy vr l in
+    action :=  dispatcher game !region r !p !player f max_f delay_even delay_odd !even_set !odd_set pre rd_en' target' tar_en' !max_col r_strategy subgame_vr reg_strategy vr l;
+    while !action <> 0 do
+      incr tot_query;
+      incr queries;
+      if !action > 1
+      then (
+        incr tot_promo;
+        incr promo;
+      );
+      successor game !region r p !player !action f max_f delay_even delay_odd even_set odd_set r_strategy reg_strategy vr l;
+      let (target,tar_en,rd_en) = query game region r !p player !action att_qP att_qO subgame_vr reg_strategy vr l in
+      action :=  dispatcher game !region r !p !player f max_f delay_even delay_odd !even_set !odd_set pre rd_en target tar_en !max_col r_strategy subgame_vr reg_strategy vr l;
+    done;
+    if !promo > !max_promo
+    then max_promo := !promo;
+    if !queries > !max_query
+    then max_query := !queries;
+    incr wr_count;
+    if BitSet.count !region = !node_count
+    then (
+      empty := true;
+      for i = 0 to l - 1 do
+        if reg_strategy.(i) <> -1
+        then str_out.(i) <- reg_strategy.(i);
+        if BitSet.is_set !region i
+        then sol_set solution i !player;
+      done;
+    )
+    else (
+      let region' = attr_bit game vr att_qP att_qO reg_strategy !player !region (BitSet.enum !region) in
+      node_count := 0;
+      empty := true;
+      p := 0;
+      action := 0;
+      for i = 0 to l - 1 do
+        if reg_strategy.(i) <> -1
+        then str_out.(i) <- reg_strategy.(i);
+        if BitSet.is_set region' i
+        then solution.(i) <- !player;
+        r_strategy.(i) <- -1;
+        if solution.(i) = plr_undef && BitSet.is_set vr i
+        then (
+          incr node_count;
+          empty := false;
+          let pr = pg_get_priority game i in
+          r.(i) <- pr;
+          f.(i) <- pr;
+          if pr > !p then p := pr;
+          BitSet.set subgame_vr i;
+        )
+        else (
+          r.(i) <- -1;
+          f.(i) <- -1;
+          BitSet.unset vr i;
+          BitSet.unset subgame_vr i;
+        );
+      done;
+      player := plr_undef;
+      max_col := 1 + !p;
+      promo := 0;
+      queries := 0;
+      max_f := 0;
+      even_set := FSet.empty;
+      odd_set := FSet.empty;
+      delay_even := FMap.empty;
+      delay_odd := FMap.empty;
+    );
+  done;
+  (solution,str_out,!tot_query,!tot_promo,!max_query,!max_promo,!wr_count);;
+
+let ppdelaysolve game =
+  let msg_tagged v = message_autotagged v (fun _ -> "DP") in
+  let (solution,strategy,queries,proms,maxq,maxp,wr) = search game in
+  msg_tagged 2 (fun _ -> "\n");
+  msg_tagged 2 (fun _ -> "Number of queries: " ^ string_of_int queries ^ "\n");
+  msg_tagged 2 (fun _ -> "Number of promotions: " ^ string_of_int proms ^ "\n");
+  msg_tagged 2 (fun _ -> "Maximum number of queries: " ^ string_of_int maxq ^ "\n");
+  msg_tagged 2 (fun _ -> "Maximum number of promotions: " ^ string_of_int maxp ^ "\n");
+  msg_tagged 2 (fun _ -> "Number of dominions: " ^ string_of_int wr ^ "\n");
+  (solution,strategy);;
+
+let solve game = ppdelaysolve game;;
+
+register_solver solve "priopromdel" "dp" "use the Delayed Promotion procedure";;
+
+let solveuniv game =
+  let opt = (universal_solve_init_options_verbose !universal_solve_global_options) in
+  universal_solve opt ppdelaysolve game;;
+
+register_solver solveuniv "priopromdeluniv" "dpuniv" "use the Delayed Promotion procedure integrated with the universal solver";;

--- a/src/solvers/priopromdelay.mli
+++ b/src/solvers/priopromdelay.mli
@@ -1,0 +1,3 @@
+open Paritygame ;;
+
+val solve : paritygame -> solution * strategy

--- a/src/solvers/priopromplus.ml
+++ b/src/solvers/priopromplus.ml
@@ -1,0 +1,239 @@
+
+(*******************************************************************************
+ *                                                                             *
+ * The Modified Priority Promotion Procedure                                   *
+ *                                                                             *
+ * from:                                                                       *
+ * M. Benerecetti, D. Dell'Erba, and F. Mogavero.                              *
+ * A Delayed Promotion Policy for Parity Games,                                *
+ * GandALF 2016, EPTCS 226, pp. 30-45, 2016                                    *
+ *                                                                             *
+ ******************************************************************************)
+
+open Basics;;
+open Paritygame;;
+open Univsolve;;
+open Paritygamebitset;;
+open Solvers;;
+
+let query game region r p player was_open att_qP att_qO subgame_vr reg_strategy vr l =
+  let r_dom = bit_dom_array_bound r l p in
+  if was_open = 1
+  then BitSet.differentiate subgame_vr !region
+  else (
+    for i = 0 to l - 1 do
+      if (BitSet.is_set vr i) && not (BitSet.is_set r_dom i)
+      then BitSet.set subgame_vr i
+      else BitSet.unset subgame_vr i
+    done;
+  );
+  player := plr_benefits p;
+  let target = BitSet.create l in
+  for i = 0 to l - 1 do
+    reg_strategy.(i) <- -1;
+    if r.(i) = p
+    then BitSet.set target i
+  done;
+  let reg_en = BitSet.enum target in
+  region := attr_bit game subgame_vr att_qP att_qO reg_strategy !player target (Enum.clone reg_en);
+  (target,reg_en,BitSet.enum r_dom);;
+
+let dispatcher game region r player pre r_enum target target_enum max_col r_strategy subgame_vr reg_strategy vr l =
+  let pre_set = BitSet.diff vr region in
+  Enum.iter (fun v -> BitSet.unset pre_set v) (Enum.clone r_enum);
+  Enum.iter (fun i ->
+      let pl = pg_get_owner game i in
+      let ws = pg_get_successors game i in
+      if pl = player
+      then (
+        if r_strategy.(i) = -1
+        then (
+          let w = ns_fold (fun b -> fun w -> if (b > -1 || not (BitSet.is_set vr w) || not (BitSet.is_set region w)) then b else w) (-1) ws in
+          if w > -1 then reg_strategy.(i) <- w;
+        )
+        else reg_strategy.(i) <- r_strategy.(i);
+      )
+    ) target_enum;
+  pre_bit game pre subgame_vr (plr_opponent player) pre_set l;
+  if not (is_empty_bset (BitSet.inter pre target) l)
+  then 1
+  else (
+    let r_pl = BitSet.create l in
+    if player = plr_Even
+    then Enum.iter (fun i -> if r.(i) mod 2 = 0 then BitSet.set r_pl i) r_enum
+    else Enum.iter (fun i -> if r.(i) mod 2 = 1 then BitSet.set r_pl i) r_enum;
+    let min = ref (max_col) in
+    Enum.iter (fun v ->
+        let ws = pg_get_successors game v in
+        let color = ref (max_col) in
+        ns_iter (fun w -> if BitSet.is_set vr w && BitSet.is_set r_pl w
+                  then (
+                    if r.(w) < !color
+                    then (
+                      color := r.(w);
+                      if r.(w) < !min
+                      then min := r.(w);
+                    )
+                  );
+                ) ws;
+      ) (BitSet.enum region);
+    if !min <> (max_col)
+    then !min
+    else 0;
+  );;
+
+
+let successor game region r p player action r_strategy reg_strategy vr l =
+  if action = 1
+  then (
+    let new_p = ref 0 in
+    for i = 0 to l - 1 do
+      if BitSet.is_set region i
+      then r.(i) <- !p;
+      if reg_strategy.(i) <> -1
+      then r_strategy.(i) <- reg_strategy.(i);
+      if r.(i) < !p && r.(i) > !new_p
+      then new_p := r.(i);
+    done;
+    p := !new_p;
+  )
+  else (
+    p := action;
+    for i = 0 to l - 1 do
+      if BitSet.is_set region i
+      then r.(i) <- !p
+      else (
+        if r.(i) < !p && plr_benefits r.(i) <> player && BitSet.is_set vr i
+        then (
+          let pr = pg_get_priority game i in
+          r.(i) <- pr;
+          r_strategy.(i) <- -1;
+        );
+      );
+      if reg_strategy.(i) <> -1
+      then r_strategy.(i) <- reg_strategy.(i);
+    done;
+  );;
+
+let search game =
+  let tot_query = ref 0 in
+  let tot_promo = ref 0 in
+  let queries = ref 0 in
+  let promo = ref 0 in
+  let max_query = ref 0 in
+  let max_promo = ref 0 in
+  let wr_count = ref 0 in
+  let l = pg_size game in
+  let reg_strategy = Array.make l (-1) in
+  let r_strategy = Array.make l (-1) in
+  let solution = sol_create game in
+  let str_out = Array.make l (-1) in
+  let empty = ref false in
+  let p = ref (-1) in
+  let r = Array.make l (-1) in
+  let region = ref (BitSet.create l) in
+  let vr = collect_nodes_bit game l in
+  let subgame_vr = BitSet.copy vr in
+  let node_count = ref 0 in
+  let pre = BitSet.create l in
+  let att_qP = Queue.create () in
+  let att_qO = Queue.create () in
+  let action = ref 0 in
+  let player = ref plr_undef in
+  for i = 0 to l - 1 do
+    if BitSet.is_set vr i
+    then (
+      incr node_count;
+      let pr = pg_get_priority game i in
+      r.(i) <- pr;
+      if pr > !p then p := pr;
+    );
+  done;
+  let max_col = ref (1 + !p) in
+  while not !empty do
+    incr tot_query;
+    incr queries;
+    let (target',tar_en',rd_en') = query game region r !p player !action att_qP att_qO subgame_vr reg_strategy vr l in
+    action := dispatcher game !region r !player pre rd_en' target' tar_en' !max_col r_strategy subgame_vr reg_strategy vr l;
+    while !action <> 0 do
+      incr tot_query;
+      incr queries;
+      if !action > 1
+      then (
+        incr tot_promo;
+        incr promo;
+      );
+      successor game !region r p !player !action r_strategy reg_strategy vr l;
+      let (target,tar_en,rd_en) = query game region r !p player !action att_qP att_qO subgame_vr reg_strategy vr l in
+      action := dispatcher game !region r !player pre rd_en target tar_en !max_col r_strategy subgame_vr reg_strategy vr l;
+    done;
+    if !promo > !max_promo
+    then max_promo := !promo;
+    if !queries > !max_query
+    then max_query := !queries;
+    incr wr_count;
+    if BitSet.count !region = !node_count
+    then (
+      empty := true;
+      for i = 0 to l - 1 do
+        if reg_strategy.(i) <> -1
+        then str_out.(i) <- reg_strategy.(i);
+        if BitSet.is_set !region i
+        then sol_set solution i !player;
+      done;
+    )
+    else (
+      let region' = attr_bit game vr att_qP att_qO reg_strategy !player !region (BitSet.enum !region) in
+      node_count := 0;
+      empty := true;
+      p := 0;
+      action := 0;
+      for i = 0 to l - 1 do
+        if reg_strategy.(i) <> -1
+        then str_out.(i) <- reg_strategy.(i);
+        if BitSet.is_set region' i
+        then solution.(i) <- !player;
+        r_strategy.(i) <- -1;
+        if solution.(i) = plr_undef && BitSet.is_set vr i
+        then (
+          incr node_count;
+          empty := false;
+          let pr = pg_get_priority game i in
+          r.(i) <- pr;
+          if pr > !p then p := pr;
+          BitSet.set subgame_vr i;
+        )
+        else (
+          r.(i) <- -1;
+          BitSet.unset vr i;
+          BitSet.unset subgame_vr i;
+        );
+      done;
+      player := plr_undef;
+      max_col := 1 + !p;
+      promo := 0;
+      queries := 0;
+    );
+  done;
+  (solution,str_out,!tot_query,!tot_promo,!max_query,!max_promo,!wr_count);;
+
+let ppplussolve game =
+  let msg_tagged v = message_autotagged v (fun _ -> "PP+") in
+  let (solution,strategy,queries,proms,maxq,maxp,wr) = search game in
+  msg_tagged 2 (fun _ -> "\n");
+  msg_tagged 2 (fun _ -> "Number of queries: " ^ string_of_int queries ^ "\n");
+  msg_tagged 2 (fun _ -> "Number of promotions: " ^ string_of_int proms ^ "\n");
+  msg_tagged 2 (fun _ -> "Maximum number of queries: " ^ string_of_int maxq ^ "\n");
+  msg_tagged 2 (fun _ -> "Maximum number of promotions: " ^ string_of_int maxp ^ "\n");
+  msg_tagged 2 (fun _ -> "Number of dominions: " ^ string_of_int wr ^ "\n");
+  (solution,strategy);;
+
+let solve game = ppplussolve game;;
+
+register_solver solve "priopromplus" "pp+" "use the modified Priority Promotion procedure";;
+
+let solveuniv game =
+  let opt = (universal_solve_init_options_verbose !universal_solve_global_options) in
+  universal_solve opt ppplussolve game;;
+
+register_solver solveuniv "priopromplusuniv" "pp+univ" "use the modified Priority Promotion procedure integrated with the universal solver";;

--- a/src/solvers/priopromplus.mli
+++ b/src/solvers/priopromplus.mli
@@ -1,0 +1,3 @@
+open Paritygame ;;
+
+val solve : paritygame -> solution * strategy

--- a/src/solvers/priopromrecovery.ml
+++ b/src/solvers/priopromrecovery.ml
@@ -1,0 +1,274 @@
+
+(*******************************************************************************
+ *                                                                             *
+ * The Region Recovery Procedure                                               *
+ *                                                                             *
+ * from:                                                                       *
+ * M. Benerecetti, D. Dell'Erba, and F. Mogavero.                              *
+ * Improving Priority Promotion for Parity Games,                              *
+ * HVC 2016, LNCS 10028, Springer, pp. 1-17, 2016.                             *
+ *                                                                             *
+ ******************************************************************************)
+
+open Basics;;
+open Paritygame;;
+open Univsolve;;
+open Paritygamebitset;;
+open Solvers;;
+
+
+let query game region r p player was_open att_qP att_qO subgame_vr reg_strategy vr l =
+  let r_dom = bit_dom_array_bound r l p in
+  if was_open = 1
+  then BitSet.differentiate subgame_vr !region
+  else (
+    for i = 0 to l - 1 do
+      if (BitSet.is_set vr i) && not (BitSet.is_set r_dom i)
+      then BitSet.set subgame_vr i
+      else BitSet.unset subgame_vr i
+    done;
+  );
+  player := plr_benefits p;
+  let target = BitSet.create l in
+  for i = 0 to l - 1 do
+    reg_strategy.(i) <- -1;
+    if r.(i) = p
+    then BitSet.set target i
+  done;
+  let reg_en = BitSet.enum target in
+  region := attr_bit game subgame_vr att_qP att_qO reg_strategy !player target (Enum.clone reg_en);
+  (target,reg_en,BitSet.enum r_dom);;
+
+let dispatcher game region r player pre r_enum target target_enum max_col r_strategy subgame_vr reg_strategy vr l =
+  let pre_set = BitSet.diff vr region in
+  Enum.iter (fun v -> BitSet.unset pre_set v) (Enum.clone r_enum);
+  Enum.iter (fun i ->
+      let pl = pg_get_owner game i in
+      let ws = pg_get_successors game i in
+      if pl = player
+      then (
+        if r_strategy.(i) = -1
+        then (
+          let w = ns_fold (fun b -> fun w -> if (b > -1 || not (BitSet.is_set vr w) || not (BitSet.is_set region w)) then b else w) (-1) ws in
+          if w > -1 then reg_strategy.(i) <- w;
+        )
+        else reg_strategy.(i) <- r_strategy.(i);
+      )
+    ) target_enum;
+  pre_bit game pre subgame_vr (plr_opponent player) pre_set l;
+  if not (is_empty_bset (BitSet.inter pre target) l)
+  then 1
+  else (
+    let r_pl = BitSet.create l in
+    if player = plr_Even
+    then Enum.iter (fun i -> if r.(i) mod 2 = 0 then BitSet.set r_pl i) r_enum
+    else Enum.iter (fun i -> if r.(i) mod 2 = 1 then BitSet.set r_pl i) r_enum;
+    let min = ref (max_col) in
+    Enum.iter (fun v ->
+        let ws = pg_get_successors game v in
+        let color = ref (max_col) in
+        ns_iter (fun w -> if BitSet.is_set vr w && BitSet.is_set r_pl w
+                  then (
+                    if r.(w) < !color
+                    then (
+                      color := r.(w);
+                      if r.(w) < !min
+                      then min := r.(w);
+                    )
+                  );
+                ) ws;
+      ) (BitSet.enum region);
+    if !min <> (max_col)
+    then !min
+    else 0;
+  );;
+
+let successor game region r p action r_strategy reg_strategy l =
+  if action = 1
+  then (
+    let new_p = ref 0 in
+    for i = 0 to l - 1 do
+      if BitSet.is_set region i
+      then r.(i) <- !p;
+      if reg_strategy.(i) <> -1
+      then r_strategy.(i) <- reg_strategy.(i);
+      if r.(i) < !p && r.(i) > !new_p
+      then new_p := r.(i);
+    done;
+    p := !new_p;
+    let reg_check = ref true in
+    let reg_search = ref true in
+    let j = ref 0 in
+    while !reg_search do
+      while !j < l && !reg_check do
+        if r.(!j) = !p
+        then (
+          let pr = pg_get_priority game !j in
+          let pl = pg_get_owner game !j in
+          let ws = pg_get_successors game !j in
+          if pl = plr_benefits !p
+          then (
+            if r_strategy.(!j) > -1 && r.(r_strategy.(!j)) <> !p
+            then reg_check := false;
+          )
+          else (
+            if pr <> !p
+            then reg_check := ns_fold (fun b -> fun w -> b && r.(w) >= !p) true ws;
+          );
+        );
+        incr j;
+      done;
+      j := 0;
+      if !reg_check
+      then reg_search := false
+      else (
+        reg_check := true;
+        new_p := 0;
+        for i = 0 to l - 1 do
+          if r.(i) = !p
+          then (
+            let pr = pg_get_priority game i in
+            r.(i) <- pr;
+            r_strategy.(i) <- -1;
+          );
+          if r.(i) <= !p && r.(i) > !new_p
+          then new_p := r.(i);
+        done;
+        if !new_p = !p
+        then reg_search := false
+        else p := !new_p;
+      );
+    done;
+  )
+  else (
+    p := action;
+    for i = 0 to l - 1 do
+      if BitSet.is_set region i
+      then r.(i) <- !p;
+      if reg_strategy.(i) <> -1
+      then r_strategy.(i) <- reg_strategy.(i);
+    done;
+  );;
+
+let search game =
+  let tot_query = ref 0 in
+  let tot_promo = ref 0 in
+  let queries = ref 0 in
+  let promo = ref 0 in
+  let max_query = ref 0 in
+  let max_promo = ref 0 in
+  let wr_count = ref 0 in
+  let l = pg_size game in
+  let reg_strategy = Array.make l (-1) in
+  let r_strategy = Array.make l (-1) in
+  let solution = sol_create game in
+  let str_out = Array.make l (-1) in
+  let empty = ref false in
+  let p = ref (-1) in
+  let r = Array.make l (-1) in
+  let region = ref (BitSet.create l) in
+  let vr = collect_nodes_bit game l in
+  let subgame_vr = BitSet.copy vr in
+  let node_count = ref 0 in
+  let pre = BitSet.create l in
+  let att_qP = Queue.create () in
+  let att_qO = Queue.create () in
+  let action = ref 0 in
+  let player = ref plr_undef in
+  for i = 0 to l - 1 do
+    if BitSet.is_set vr i
+    then (
+      incr node_count;
+      let pr = pg_get_priority game i in
+      r.(i) <- pr;
+      if pr > !p then p := pr;
+    );
+  done;
+  let max_col = ref (1 + !p) in
+  while not !empty do
+    incr tot_query;
+    incr queries;
+    let (target',tar_en',rd_en') = query game region r !p player !action att_qP att_qO subgame_vr reg_strategy vr l in
+    action := dispatcher game !region r !player pre rd_en' target' tar_en' !max_col r_strategy subgame_vr reg_strategy vr l;
+    while !action <> 0 do
+      incr tot_query;
+      incr queries;
+      if !action > 1
+      then (
+        incr tot_promo;
+        incr promo;
+      );
+      successor game !region r p !action r_strategy reg_strategy l;
+      let (target,tar_en,rd_en) = query game region r !p player !action att_qP att_qO subgame_vr reg_strategy vr l in
+      action := dispatcher game !region r !player pre rd_en target tar_en !max_col r_strategy subgame_vr reg_strategy vr l;
+    done;
+    if !promo > !max_promo
+    then max_promo := !promo;
+    if !queries > !max_query
+    then max_query := !queries;
+    incr wr_count;
+    if BitSet.count !region = !node_count
+    then (
+      empty := true;
+      for i = 0 to l - 1 do
+        if reg_strategy.(i) <> -1
+        then str_out.(i) <- reg_strategy.(i);
+        if BitSet.is_set !region i
+        then sol_set solution i !player;
+      done;
+    )
+    else (
+      let region' = attr_bit game vr att_qP att_qO reg_strategy !player !region (BitSet.enum !region) in
+      node_count := 0;
+      empty := true;
+      p := 0;
+      action := 0;
+      for i = 0 to l - 1 do
+        if reg_strategy.(i) <> -1
+        then str_out.(i) <- reg_strategy.(i);
+        if BitSet.is_set region' i
+        then solution.(i) <- !player;
+        r_strategy.(i) <- -1;
+        if solution.(i) = plr_undef && BitSet.is_set vr i
+        then (
+          incr node_count;
+          empty := false;
+          let pr = pg_get_priority game i in
+          r.(i) <- pr;
+          if pr > !p then p := pr;
+          BitSet.set subgame_vr i;
+        )
+        else (
+          r.(i) <- -1;
+          BitSet.unset vr i;
+          BitSet.unset subgame_vr i;
+        );
+      done;
+      player := plr_undef;
+      max_col := 1 + !p;
+      promo := 0;
+      queries := 0;
+    );
+  done;
+  (solution,str_out,!tot_query,!tot_promo,!max_query,!max_promo,!wr_count);;
+
+let pprecoverysolve game =
+  let msg_tagged v = message_autotagged v (fun _ -> "RR") in
+  let (solution,strategy,queries,proms,maxq,maxp,wr) = search game in
+  msg_tagged 2 (fun _ -> "\n");
+  msg_tagged 2 (fun _ -> "Number of queries: " ^ string_of_int queries ^ "\n");
+  msg_tagged 2 (fun _ -> "Number of promotions: " ^ string_of_int proms ^ "\n");
+  msg_tagged 2 (fun _ -> "Maximum number of queries: " ^ string_of_int maxq ^ "\n");
+  msg_tagged 2 (fun _ -> "Maximum number of promotions: " ^ string_of_int maxp ^ "\n");
+  msg_tagged 2 (fun _ -> "Number of dominions: " ^ string_of_int wr ^ "\n");
+  (solution,strategy);;
+
+let solve game = pprecoverysolve game;;
+
+register_solver solve "priopromrec" "rr" "use the Region Recovery procedure";;
+
+let solveuniv game =
+  let opt = (universal_solve_init_options_verbose !universal_solve_global_options) in
+  universal_solve opt pprecoverysolve game;;
+
+register_solver solveuniv "priopromrecuniv" "rruniv" "use the Region Recovery procedure integrated with the universal solver";;

--- a/src/solvers/priopromrecovery.mli
+++ b/src/solvers/priopromrecovery.mli
@@ -1,0 +1,3 @@
+open Paritygame ;;
+
+val solve : paritygame -> solution * strategy

--- a/src/solvers/succinctsmallprogress.ml
+++ b/src/solvers/succinctsmallprogress.ml
@@ -1,0 +1,489 @@
+(* Copyright 2017 Patrick Totzke
+ * This file is released under the BSD licence. For details see https://opensource.org/licenses/BSD-3-Clause.
+ *
+ * This is a (completely imperative) implementation of Jurdzinski/Lazic's
+ * Succinct small progress measure algorithm: https://arxiv.org/abs/1702.05051 .
+ *)
+
+open Basics ;;
+open Paritygame ;;
+open Univsolve;;
+open Solvers;;
+open Tcsqueue;;
+
+
+(* -------------  AUXILIARY FUNCTIONS -------------------------------------- *)
+(* define local logging functions *)
+let log_debug msg = message_autotagged 3 (fun _ -> "SSMP") (fun _ -> msg ^ "\n") ;;
+let log_verb msg = message_autotagged 2 (fun _ -> "SSMP") (fun _ -> msg ^ "\n") ;;
+let log_info msg = message_autotagged 1 (fun _ -> "SSMP") (fun _ -> msg ^ "\n") ;;
+
+
+(* define logarithm base 2. Thanks for nothing ocaml. *)
+let ld x = int_of_float(ceil (log (float_of_int x) /. log 2.0));;
+
+
+(* find the largest index <= start in an array such that the corresponding *)
+(* element satisfies the given predicate *)
+let rec find_lastindex_with a pred start =
+    if start = -1 then -1 else
+    if pred a.(start) then start else
+        find_lastindex_with a pred (start-1)
+;;
+
+
+(* This renders a Paritygame.nodeset as e.g. as "{1,2,3,4}".
+ * We'll use it when logging the successors of a node. *)
+let ns_format nodeset = 
+    let commajoin l r = match l with
+    | "" -> r
+    | _ -> l ^ "," ^ r in
+    let stringtuple = List.map string_of_int (ns_nodes nodeset) in
+    "{" ^ (List.fold_left commajoin "" stringtuple) ^ "}"
+;;
+
+
+
+(* -------------  BITSTRINGS ---------------------------------------------- *)
+(* Our procedure is based on a particular ordering on bitstrings.
+ * We define bitstrings as arrays of Bools; the ordering is defined
+ * in the function bitstring_compare below.
+ *)
+type bitstring = bool array;;
+
+
+(* use the alias "eps" to denote the the empty bitstring *)
+let eps = [||];;
+
+
+(* format a bitstring as a normal string for logging *)
+let bitstring_format bs = 
+    if bs = eps
+      then "ε"
+      else
+        let bool_to_char b = if b then '1' else '0'in
+        String.init (Array.length bs) (fun i -> (bool_to_char bs.(i)))
+;;
+
+
+(* bitstring comparison. This returns -1,0 or 1, as the standard "compare" function
+ *
+ * For every but b and bitstrings s,s' we have
+ * 1) 0s < eps
+ * 2) eps < 1s 
+ * 3) bs < bs' <=> s < s'
+ *)
+let rec bitstring_compare x y = 
+  let length_x = Array.length x in
+  let length_y = Array.length y in
+  (* recursively traverse x and y from left to right, starting at index i *)
+  let rec aux i =
+      if i < length_x then (* x has element x.(i) *)
+          if i < length_y then (* y has element y.(i) *)
+              if x.(i) <> y.(i) then compare x.(i) y.(i)
+              else aux (i+1)
+          else (* y.(i)=eps, x not *)
+              if x.(i) then 1 else -1
+      else (* x.(i)=eps *)
+          if i < length_y then (* y has element y.(i), x.(i)=eps*)
+              if y.(i) then -1 else 1
+          else (* y.(i)=eps = x.(i) *)
+              0
+  in
+  aux 0
+;;
+
+
+(* aliases for <, =, > *)
+let bitstring_less x y = (bitstring_compare x y) = -1;;
+let bitstring_greater x y = (bitstring_compare x y) = 1;;
+let bitstring_equal x y = (bitstring_compare x y) = 0;;
+
+(* -------------  END OF BITSTRING DEFINITIONS --------------- *)
+
+
+
+(* -------------- ADAPTIVE COUNTERS -------------------------- *)
+(* An adaptive counters is either Top or an array of bitstrings.
+ * The length of the tuple is unspecified in the type definition and formatting;
+ * All other functions work on "h-counters": tuples of length h.
+ * *)
+type adaptivecounter = Top | AC of bitstring array;;
+
+
+(* format adaptive counters in tuple notation for human consumption *)
+let ac_format ac = 
+    let commajoin l r = match l with
+    | "" -> r
+    | _ -> l ^ "," ^ r in
+    match ac with
+    | Top -> "T"
+    | AC bitstrings ->
+        let stringtuple = Array.map bitstring_format bitstrings in
+        "(" ^ (Array.fold_left commajoin "" stringtuple) ^ ")"
+;;
+
+
+(* compare adaptive h-counters lexicographically based on bitstring comparisons.
+ *
+ * INPUTS:
+ * - integers h and p,
+ * - adaptive h-counters x and y. These are either Top or bitstrings of length h.
+ * OUTPUT: -1, 0 or 1
+ * The comparison is only for the components corresponding to priorities >= p.
+ * This means that we compare only prefixes of length h-(p/2).
+ *)
+let ac_compare h p x y = 
+    match (x,y) with
+    | (Top, Top) -> 0  (* hardcode results for artificial top element *)
+    | (Top, _) -> 1
+    | (_, Top) -> -1
+    | (AC acx, AC acy) ->
+        (* use bitstring comparisons lexicographically otherwise *)
+        let maxindex = h - (p/2) in (* truncate after the maximal interesting index*)
+        let rec aux i =  (* compare indices from left to right *)
+            if i = maxindex
+            then 0
+            else  (* use bitstrin comparison *)
+              if acx.(i) <> acy.(i)
+              then (* done if bitstrings are different *)
+                  bitstring_compare acx.(i) acy.(i)
+              else (* otherwise look at next index*)
+                  aux (i+1)
+        in
+        aux 0
+;;
+
+
+(* aliases for <, =, >.
+ * These are actually operations <|_p, =|_p and >|_p for ataptive h-counters from the paper.
+ *)
+let ac_less h p x y = (ac_compare h p x y) = -1;;
+let ac_greater h p x y = (ac_compare h p x y) = 1;;
+let ac_equal h p x y = (ac_compare h p x y) = 0;;
+
+
+(* computes the combined length of the bistrings in all components
+corresponding to parities >=p, in the adaptive h-counter ac.
+Unless ac=Top, this means summing up the lengths of the first h-(p/2) entries.
+*)
+let ac_bitstring_length h p ac =
+    match ac with
+    | Top -> 0
+    | AC bitstrings ->
+            let sum = ref 0 in
+            for i = 0 to (h-(p/2))-1 do
+                sum := !sum + (Array.length bitstrings.(i))
+                done;
+            !sum
+;;
+
+
+(* truncate adaptive h-counter for priority p.
+ * This means replacing the last (p/2) components by eps *)
+let ac_truncate h p ac = 
+    match ac with
+    | Top -> Top
+    | AC bitstrings ->
+    let pindex = h - (p/2)-1 in
+    AC (Array.init h (fun i -> if i > pindex then [||] else bitstrings.(i)))
+;;
+
+
+(* compute the minimal l-bouded adaptive h-counter:
+* this is of the form (000..0,eps,eps,...eps), where the first component has l zeros
+* and the remaining h-1 components are eps. *)
+let ac_min l h = AC (Array.append
+                [|(Array.make l false)|] (* lx0 on the first position *)
+                (Array.make (h-1) eps)  (* eps on the last h-1 positions *)
+);;
+
+
+(* compute the least l-bounded adaptive h-counter p-above a given counter ac. *)
+let ac_least_above l h p ac = 
+    match ac with
+    | Top -> Top      (* If the given ac is Top, just return Top. *)
+    | AC original ->  (* do some work otherwise *)
+    
+    (* identify the largest array index after truncation. *)
+    (* if p-truncation yields the empty tuple the next p-larger counter is Top. *)
+    let pindex = h - (p/2)-1 in
+    if pindex = -1
+    then
+        Top
+    else
+        (
+        (* define some arbitrary h-counter below Top to write to. *)
+        let resultarr = Array.copy original in
+        let result = ref Top in  (* this is the default return value *)
+        
+
+        (* There are three cases, depending on the total length of the bitstrings,
+         * and on the last non-empty component of the counter *)
+        let bitstring_length = ac_bitstring_length h p ac in
+        if bitstring_length < l
+        then (
+            (* CASE 1: the total bitstring length can be extended *)
+            (* update resultarr.pindex  to  original.pindex · 100..0 *)
+            let zeros = Array.make (l-(bitstring_length)-1) false in
+            resultarr.(pindex) <- Array.concat [original.(pindex); [|true|]; zeros];
+            (* set all following elemts to eps *)
+            Array.fill resultarr (pindex+1) (h-pindex-1) eps;
+            result := AC resultarr;
+        )
+        else ( (* the total bitstring is already of maximal length *)
+            (* find the last nonempty bitstring of the ac before or at pindex *)
+            (* This exists since bitstring_length = l. *)
+            let lne_index = find_lastindex_with original (fun x -> x!=eps) pindex in
+            let lne = original.(lne_index) in
+            let lne_length = Array.length lne in
+            log_debug ("lne_index: " ^ (string_of_int lne_index  ));
+
+            (* find the last bit 0 in this nonempty bistring *)
+            let zeroindex = find_lastindex_with lne (fun x -> x=false)
+                                                    (Array.length lne-1) in
+            log_debug ("zeroindex: " ^ (string_of_int lne_index  ));
+
+            if zeroindex > -1
+            then (
+                (* CASE 2: the total length is l and the least non-empty component has zeros. *)
+                (* copy the prefix before the last zero to resultarr *)
+                resultarr.(lne_index) <- Array.init (zeroindex) (fun i -> lne.(i));
+                (* unless lne_index is maximal, add zeros to the next larger index *)
+                if lne_index < h-1
+                then(
+                    let suffix_length = (lne_length - zeroindex) in
+                    let zeros = Array.make suffix_length false in
+                    resultarr.(lne_index+1) <- zeros;
+                    log_debug ("suffix: " ^ (bitstring_format zeros));
+                    log_debug ("resultarr: " ^ (ac_format (AC resultarr)));
+                )
+                else ();
+                (* fill the remaining indices with eps to get a h-tuple *)
+                if lne_index < h -2
+                then
+                    Array.fill resultarr (lne_index+2) (h-lne_index-2) eps
+                else ();
+                result := AC resultarr;  (* set result for this case *)
+            )
+            else (
+                (* CASE 3: the total length is l and the least non-empty component has NO zeros. *)
+                (* lne is of the form 111..1 *)
+                if lne_index = 0
+                then 
+                    (* we have l 1's on the first position, the next higher up is Top *)
+                    result := Top
+                else
+                (
+                    (* if lne is at position (j+1)>0, set resultarr.j to (original.j 1 0000) *)
+                    resultarr.(lne_index-1) <- Array.concat [
+                        original.(lne_index-1);
+                        [|true|];
+                        (Array.make (lne_length-1) false)
+                    ];
+                    (* fill the remaining indices with eps to get a h-tuple *)
+                    Array.fill resultarr (lne_index) (h-lne_index) eps;
+                result := AC resultarr;  (* set result for this case *)
+                );
+            );
+        );
+        log_debug ("the least "
+          ^ (string_of_int h) ^ "-counter "
+          ^ (string_of_int p) ^ "-above "
+          ^ (ac_format (AC original))
+          ^ " is " ^ (ac_format !result));
+        !result
+        );
+;;
+(* -------------- END OF ADAPTIVE COUNTERS DEFINITIONS ---------------- *)
+
+
+
+(* -------------- PROGRESS MEASURES ----------------------------------- *)
+(* A progress measure maps each of the n states to an adaptive counter. We
+ * represent this as (n-1)-array of adaptive counters *)
+type progressmeasure = adaptivecounter array;;
+
+
+(* format progress measures for logging *)
+let pm_format mu = 
+    let stringtuple = Array.mapi (fun i v -> (string_of_int i) ^ " -> " ^ (ac_format v) ^ "\n") mu in
+    Array.fold_left (^) "" stringtuple
+;;
+(* -------------- END OF PROGRESS MEASURE DEFINITIONSS ---------------- *)
+
+
+
+(* -------------- MAIN SOLVER ----------------------------------------- *)
+let solve' game =
+    log_debug "Now solving the following subgame:";
+    log_debug (format_game game);
+
+    (* compute some constants from the game *)
+    let n = pg_size game in               (* number of vertices *)
+    let maxprio = pg_max_prio game in     (* number of priorities *)
+    let d = maxprio + (maxprio mod 2) in  (* largest even number >= maxprio *)
+    let l = ld n in                       (* maximal length of bitstrings *)
+    let h = (d/2) in                      (* length of the adaptive counters *)
+
+    log_info ("The game has "
+      ^ (string_of_int n) ^ " states with maximal priority "
+      ^ (string_of_int maxprio)
+      ^ ". We are looking at "
+      ^ (string_of_int l) ^ "-bounded adaptive "
+      ^ (string_of_int h) ^ "-counters. "
+    );
+
+    (* compute lift(mu,v,w): the least s >= v progressive in mu[v->s] *)
+    (* here, mu is a progress measure, and v and w are nodes (integers) *)
+    let lift mu v w = 
+        let vprio = pg_get_priority game v in
+        log_debug ("computing lift for nodes "
+              ^ (nd_show v) ^ " with measure " ^ (ac_format mu.(v))
+              ^" and node "
+              ^ (nd_show w) ^ " with measure " ^ (ac_format mu.(w))
+              );
+
+        let res = ref Top in
+        if even vprio
+        then (
+            (* v has even prio *)
+            if (ac_less h vprio mu.(v) mu.(w))
+            then (
+                res := if mu.(w) = Top then Top else (ac_truncate h vprio mu.(w));
+                log_debug ("truncate for prio " ^ (string_of_int vprio));
+            )
+            else res := mu.(v)
+        )
+        else 
+            (* v has odd prio *)
+            if (ac_greater h vprio mu.(v) mu.(w))
+            then res := mu.(v)
+            else res := (ac_least_above l h vprio mu.(w));
+        
+        log_debug ("lift of "
+        ^ (ac_format mu.(v))
+        ^ " and "
+        ^ (ac_format mu.(w))
+        ^ " is "
+        ^ (ac_format !res)
+        );
+        !res
+    in
+
+    (* compute the pair (w,lift(mu,v,w)) - a successor of v and its lifting -
+     * which maximizes or minimizes the second component (depending on who owns node v)
+     * among all successors of v.
+     *)
+    let best_successor_lift mu v =
+	let vplayer = pg_get_owner game v in
+	let succs = pg_get_successors game v in
+        
+        (* define order on pairs (node, lift(mu,v,node)) based on the
+         * players preference for the second component: Odd wants to maximize. *)
+        let better (a, lift_a) (b,lift_b) =
+            (if vplayer = plr_Odd then ac_greater else ac_less) h 0 lift_a lift_b in
+       
+        (* map list of successors to list of pairs (node, lift(mu,v node)) and
+         * reduce to best pair, starting with the current measure for state v. *) 
+        List.fold_left (fun a b -> if better a b then a else b)
+                       (v,mu.(v))
+                       (List.map (fun w -> (w, (lift mu v w))) (ns_nodes succs))
+    in
+
+    (* START OF REFINEMENT PROCEDURE *)
+    log_info ("Init small progress measure..\n");
+    (* initialize the progress measure with minimal counters for all states *)
+    let mu = Array.make n (ac_min l h) in
+    log_debug (pm_format mu);
+
+    (* create and initialize queue of dirty states
+     * the queue itself ensures that each element occurs at most once. *)
+    let queue = SingleOccQueue.create () in
+    for i = 0 to n - 1 do
+        SingleOccQueue.add i queue;
+    done;
+
+    (* update until queue is empty *)
+    log_info ("refining..");
+    while not (SingleOccQueue.is_empty queue) do
+        let v = SingleOccQueue.take queue in
+	let vplayer = pg_get_owner game v in
+	let succs = pg_get_successors game v in
+        log_verb ("Dequeued state: " ^ (string_of_int v)
+                   ^ ". Owner: " ^ (plr_show vplayer)
+                   ^ " successors: " ^ ns_format succs
+        );
+        
+        if ns_size succs > 0  (* only change mu if v has successors *)
+        then (
+            let candidate, candidate_lift = best_successor_lift mu v in
+            log_verb ("candidate "
+              ^ (nd_show candidate)
+              ^ " with lift: " ^ (ac_format candidate_lift)
+            );
+
+            if (candidate_lift != mu.(v))
+            then (
+                mu.(v) <- candidate_lift;
+		log_verb ("Updating progress measure.");
+		log_debug (pm_format mu);
+                let predecessors = (pg_get_predecessors game v) in
+		log_verb ("Enqueuing predecessors of "
+                  ^ (string_of_int v)
+                  ^ " : " ^ (ns_format predecessors)
+                );
+                ns_iter (fun j -> SingleOccQueue.add j queue) predecessors;
+            )
+            else (
+                log_debug ("candidate measure "
+                  ^ (ac_format candidate_lift)
+                  ^ " is not bigger than current measure "
+                  ^ (ac_format mu.(v))
+                  ^ ". No update."
+                  );
+            );
+        )
+        else (
+        log_debug ("State " ^ (string_of_int v) ^ "has no successors");
+        );
+    done;
+
+    log_verb ("Final progress measure: \n" ^ (pm_format mu));
+
+    (* PREPARE OUTPUT *)
+    log_info ("extract winning set..");
+
+    (* Derive winning set from the SMP:
+     * even wins all states with measure Top. *)
+    let sol = sol_create game in
+    for i = 0 to n - 1 do
+        log_debug ("Checking " ^ string_of_int i);
+        sol.(i) <- if mu.(i) = Top then plr_Odd else plr_Even;
+    done;
+
+    log_info ("extract player 1 strategy..");
+    (* Derive strategy for player odd
+     * Even picks a successor with minimal - odd *)
+    let strat = Array.make n nd_undef in
+    for i = 0 to n - 1 do
+        if ((pg_get_owner game i) = plr_Odd)
+        then
+            let bestsucc, _ = best_successor_lift mu i in
+            strat.(i) <- bestsucc
+        else
+            strat.(i) <- nd_undef
+    done;
+
+    (* TODO: get player 0 strategy by solving the dual.. *)
+
+  (* Return with a winning set and winning strategy. *)
+  (sol, strat)
+;;
+(* -------------- END OF MAIN SOLVER ----------------------------------- *)
+
+
+(* wrap a universal solver around our implementation *)
+let solve game = universal_solve (universal_solve_init_options_verbose !universal_solve_global_options) solve' game;;
+(* register with pgsolver *)
+register_solver solve "succinctsmallprog" "sspm" "use the succinct small progress measure algorithm of Jurdzinski/Lazic";;


### PR DESCRIPTION
This adds an implementation the "succint small progress measures"
algorithm proposed by Jurdzinski/Lazic in https://arxiv.org/abs/1702.05051.

The special comparisons for bitstrings and derived bounded adaptive
counters are done explicitly in ocaml, which is slow.

So far, this only derives a winning strategy for player 1
and sets the strategy for player 0 to a trivial bogus strategy.