### PR TITLE
External solver

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -16,12 +16,13 @@ Plugins:     META
 BuildTools: ocamlbuild
 Library "pgsolver"
   Path:       src
-  BuildDepends: num, str, TCSLib, extlib, ocaml-sat-solvers, minisat
+  BuildDepends: num, str, TCSLib, extlib, ocaml-sat-solvers, minisat, unix, threads
   Modules: pgsolver/Basics, pgsolver/Info,
            paritygame/Paritygame, paritygame/Verification, paritygame/Univsolve, paritygame/Solvers,
            paritygame/Solverregistry, paritygame/Mdp, paritygame/Paritygamebitset, paritygame/Parsers,
            paritygame/Specialsolve, paritygame/Transformations,
-           solvers/Bigstep, solvers/Dominiondecomp, solvers/Fpiter, solvers/Genetic, solvers/Guessstrategy,
+           solvers/Bigstep, solvers/Dominiondecomp, solvers/Externalsolver,
+           solvers/Fpiter, solvers/Genetic, solvers/Guessstrategy,
            solvers/Localmodelchecker, solvers/Optstratimprov, solvers/Prioprom, solvers/Priopromdelay,
            solvers/Priopromplus, solvers/Priopromrecovery, solvers/Recursive, solvers/Satsolve, solvers/Smallprogress,
            solvers/Stratimpralgs, solvers/Stratimprdisc, solvers/Stratimprlocal, solvers/Stratimprlocal2,
@@ -35,7 +36,7 @@ Library "pgsolver"
            generators/Randomgame, generators/Laddergame, generators/Clusteredrandomgame, generators/Cliquegame,
            generators/Modelcheckerladder, generators/Recursiveladder, generators/Steadygame, generators/Jurdzinskigame,
            generators/modelchecking/Mucalculus,
-           generators/modelchecking/Elevators, generators/modelchecking/Roadworks, 
+           generators/modelchecking/Elevators, generators/modelchecking/Roadworks,
            generators/Towersofhanoi, generators/Langincl,
            generators/Recursivedullgame,
            generators/policyiter/Stratimprgen, generators/policyiter/Stratimprgenerators,

--- a/src/paritygame/paritygame.ml
+++ b/src/paritygame/paritygame.ml
@@ -359,29 +359,32 @@ let game_to_string game =
            end
 	done;
 	"parity " ^ string_of_int (n-1) ^ ";\n" ^ !s;;
- 
-let print_game game =
+
+let output_int c_out i = output_string c_out (string_of_int i);;
+let output_newline c_out = output_char c_out '\n'; flush c_out;;
+let output_game c_out game =
 	let n = pg_size game in
-	print_string ("parity " ^ string_of_int n ^ ";\n");
+	output_string c_out ("parity " ^ string_of_int (n-1) ^ ";\n");
 	for i = 0 to n - 1 do
 	  let (pr, pl, succs, _, desc) = pg_get_node game i in
 	  if pr >= 0 && pl >= 0 && pl <= 1 then (
-            print_int i;
-            print_char ' ';
-            print_int pr;
-            print_char ' ';
-            print_int pl;
-            print_char ' ';
-            print_string (String.concat "," (List.map string_of_int (ns_nodes succs)));
+            output_int c_out i;
+            output_char c_out ' ';
+            output_int c_out pr;
+            output_char c_out ' ';
+            output_int c_out pl;
+            output_char c_out ' ';
+            output_string c_out (String.concat "," (List.map string_of_int (ns_nodes succs)));
             (
              match desc with
                None -> () (* print_string (" \"" ^ string_of_int i ^ "\"") *)
-             | Some s -> if s <> "" then print_string (" \"" ^ s ^ "\"")
+             | Some s -> if s <> "" then output_string c_out (" \"" ^ s ^ "\"")
             );
-            print_char ';';
-            print_newline ()
+            output_char c_out ';';
+            output_newline c_out
            )
         done;;
+let print_game = output_game stdout;;
 
 let print_solution_strategy_parsable sol strat =
 	let n = Array.length sol in

--- a/src/paritygame/paritygame.mli
+++ b/src/paritygame/paritygame.mli
@@ -209,6 +209,7 @@ val game_to_string : paritygame -> string
 
 (* `print_game <game>' prints <game> on STDOUT s.t. it could be parsed again. *)
 val print_game : paritygame -> unit
+val output_game : out_channel -> paritygame -> unit
 
 val print_solution_strategy_parsable : solution -> strategy -> unit
 

--- a/src/paritygame/solvers.ml
+++ b/src/paritygame/solvers.ml
@@ -25,6 +25,7 @@ let fold_partial_solvers = Solverregistry.fold_partial_solvers
 let _ =
     Bigstep.register ();
     Dominiondecomp.register ();
+    Externalsolver.register ();
     Fpiter.register ();
     Genetic.register ();
     Guessstrategy.register ();

--- a/src/solvers/externalsolver.ml
+++ b/src/solvers/externalsolver.ml
@@ -1,0 +1,33 @@
+open Paritygame ;;
+open Parsers ;;
+open Univsolve ;;
+open Basics;;
+
+let pipe : in_channel -> out_channel -> unit = fun c_in c_out ->
+  let size = 4 * 1024 in
+  let buffer = Bytes.create size in
+  let eof = ref false in
+  while not !eof do
+    let len = input c_in buffer 0 size in
+    if len > 0
+    then output_string c_out (String.sub buffer 0 len)
+    else eof := true
+  done;;
+
+let solve' : Solverregistry.global_solver_factory = fun args game ->
+  let cmd = Array.get args 0 in
+  let (c_out, c_in, c_err) : in_channel * out_channel * in_channel = Unix.open_process_full cmd [||] in
+  let thread =  (Thread.create (fun _ -> pipe c_err stderr) ()) in
+  output_game c_in game;
+  close_out c_in;
+  let sol  = parse_solution c_out in
+  close_in c_out;
+  Thread.join thread;
+  let ret = Unix.close_process_full (c_out, c_in, c_err) in
+  ignore ret;
+  sol ;;
+let solve  : Solverregistry.global_solver_factory = fun args ->
+  universal_solve (universal_solve_init_options_verbose !universal_solve_global_options) (solve' args);;
+let register _ =
+  Solverregistry.register_solver_factory solve "external_solver_univ" "esuniv" "directly solve by calling an executable";
+  Solverregistry.register_solver_factory solve' "external_solver" "es" "directly solve by calling an executable";;

--- a/src/solvers/externalsolver.ml
+++ b/src/solvers/externalsolver.ml
@@ -10,7 +10,7 @@ let pipe : in_channel -> out_channel -> unit = fun c_in c_out ->
   while not !eof do
     let len = input c_in buffer 0 size in
     if len > 0
-    then output_string c_out (String.sub buffer 0 len)
+    then output_string c_out (Bytes.sub_string buffer 0 len)
     else eof := true
   done;;
 

--- a/src/solvers/externalsolver.mli
+++ b/src/solvers/externalsolver.mli
@@ -1,0 +1,5 @@
+open Paritygame ;;
+
+val solve' : string array -> paritygame -> solution * strategy
+val solve : string array -> paritygame -> solution * strategy
+val register: unit -> unit

--- a/src/tools/obfuscator.ml
+++ b/src/tools/obfuscator.ml
@@ -1,7 +1,7 @@
 open Arg;;
 open Tcsargs;;
 open Paritygame;;
-  
+
 module CommandLine =
 struct
   let input_file = ref ""
@@ -12,13 +12,17 @@ struct
 
   let reverse_edges = ref false
 
+  let seed = ref None
+
   let speclist =  [(["--disablenodeobfuscation"; "-dn"], Unit(fun _ -> obfuscate_nodes := false),
-                      "\n     keep ordering of nodes") ;
-                   (["--disableedgeobfuscation"; "-de"], Unit(fun _ -> obfuscate_edges := false), 
+                    "\n     keep ordering of nodes") ;
+                   (["--disableedgeobfuscation"; "-de"], Unit(fun _ -> obfuscate_edges := false),
                     "\n     keep ordering of edges"); (* TODO: does not make sense anymore. There is no explicit ordering visible to the outside. Option should probably be removed. *)
                    (["--justreverseedges"; "-rv"], Unit(fun _ -> obfuscate_edges := false; reverse_edges := true),
-                    "\n     reverse edges (disables a previous `-de')")] (* TODO: same as above. `reverse' is also misleading. *)
-                   
+                    "\n     reverse edges (disables a previous `-de')"); (* TODO: same as above. `reverse' is also misleading. *)
+                   (["--seed"; "-s"], Int(fun i -> seed := Some(i)),
+                    "\n     set seed value")]
+
   let header = Info.get_title "Obfuscator Tool"
 end ;;
 
@@ -40,7 +44,7 @@ let _ =
     swap.(i) <- i
   done;
 
-  Random.self_init ();
+  Option.map_default (fun i _ -> Random.init i) (Random.self_init) !seed ();
 
   if !obfuscate_nodes then (
       for k=1 to 10*(m-1) do


### PR DESCRIPTION
I currently have an external parity game solver and I would like to integrate it in your framework.

I don't know if you use an auto-formatter. Atom wanted to change a lot of tabs/spaces and empty lines. I tried to remove the majority from the pull-request.

Also in `parity_game.ml` line 367 I changed the header from the number nodes to the maximum node number, in accordance to the behaviour of `game_to_string` line 361. I don't know if this is correct.