### PR TITLE
Moved all the logic of message_depth_tagged to the inline function

### DIFF
--- a/src/pgsolver/basics.ml
+++ b/src/pgsolver/basics.ml
@@ -27,9 +27,12 @@ let message u s = if !verbosity >= u then
 let message_depth u depth s = message u (fun x -> (String.make (depth * 2) ' ') ^ s x)
 
 let message_depth_tagged u depth tag s =
-  let now = Sys.time () in
-  message_depth u depth (fun x -> "[" ^ String.capitalize_ascii (tag x) ^ ": " ^ Printf.sprintf "%.2f msec" (1000.0 *. (now -. !last_time)) ^ "]  " ^ s x);
-  last_time := now
+  message_depth u depth (fun x -> 
+		let now = Sys.time () in
+		let msg = "[" ^ String.capitalize_ascii (tag x) ^ ": " ^ Printf.sprintf "%.2f msec" (1000.0 *. (now -. !last_time)) ^ "]  " ^ s x in
+		last_time := now;
+		msg
+	)
 
 let message_depth_counter = ref 0
 let message_incrdepth _ = incr message_depth_counter


### PR DESCRIPTION
This fixes the bug where the last debug message time was updated even if the message was not displayed (issue #25). This also causes a slight speed-up for the algorithms that used tagged debugs extensively.