### PR TITLE
Add Github Actions CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,49 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        ocaml-version:
+          - 4.14
+          - 5.3
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Use OCaml ${{ matrix.ocaml-version }}
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-version }}
+          dune-cache: true
+          allow-prerelease-opam: true
+
+      - run: opam install . --deps-only --with-test
+
+      - name: build project
+        run: opam exec -- dune build
+
+      - name: run test
+        run: opam exec -- dune runtest
+
+      - run: opam install . --deps-only --with-test --criteria='+removed,+count[version-lag,solution]' --solver=builtin-0install
+
+      - name: build project with lower bounds
+        run: opam exec -- dune build
+
+      - name: run test with lower bounds
+        run: opam exec -- dune runtest


### PR DESCRIPTION
I can see that https://github.com/ocaml/opam-repository/pull/28612
is catching things at release-time which could easily have been caught earlier with a repository CI.

This therefore proposes a Github Actions CI based on https://github.com/Khady/modern-ocaml
with a few adjustments.