### PR TITLE
Adjust CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,6 +17,7 @@ jobs:
           - windows-latest
         ocaml-version:
           - 4.8
+          - 4.14
           - 5.3
         exclude:
           - os: macos-latest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,9 +16,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-version:
-          - 4.8
-          - 4.14
-          - 5.3
+          - "4.08"
+          - "4.14"
+          - "5.3"
         exclude:
           - os: macos-latest
             ocaml-compiler: "4.08"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,10 +1,10 @@
 name: Build and Test
 
 on:
+  pull_request:
   push:
     branches:
       - master
-  pull_request:
 
 jobs:
   build-and-test:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,10 +46,14 @@ jobs:
       - name: run test
         run: opam exec -- dune runtest
 
-      - run: opam install . --deps-only --with-test --criteria='+removed,+count[version-lag,solution]' --solver=builtin-0install
+      - name: install lower bounds version
+        if: matrix.os == 'ubuntu-latest'
+        run: opam install . --deps-only --with-test --criteria='+removed,+count[version-lag,solution]' --solver=builtin-0install
 
       - name: build project with lower bounds
+        if: matrix.os == 'ubuntu-latest'
         run: opam exec -- dune build
 
       - name: run test with lower bounds
+        if: matrix.os == 'ubuntu-latest'
         run: opam exec -- dune runtest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,9 +21,9 @@ jobs:
           - "5.3"
         exclude:
           - os: macos-latest
-            ocaml-compiler: "4.08"
+            ocaml-version: "4.08"
           - os: windows-latest
-            ocaml-compiler: "4.08"
+            ocaml-version: "4.08"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,6 +18,11 @@ jobs:
         ocaml-version:
           - 4.8
           - 5.3
+        exclude:
+          - os: macos-latest
+            ocaml-compiler: "4.08"
+          - os: windows-latest
+            ocaml-compiler: "4.08"
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
As a quick follow-up to #33 this
- excludes 4.08 on Windows and macOS (where compiler installation fails)
- adds 4.14 as a broadly supported, pre-5.x compiler version
